### PR TITLE
apidocs: refer to k8s 1.20 for core types

### DIFF
--- a/content/docs/apidocs/policy/v1alpha1.md
+++ b/content/docs/apidocs/policy/v1alpha1.md
@@ -35,7 +35,7 @@ rules in the policy.</p>
 <td>
 <code>metadata</code><br/>
 <em>
-<a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+<a href="https://v1-20.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -116,7 +116,7 @@ EgressSpec
 <td>
 <code>matches</code><br/>
 <em>
-<a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typedlocalobjectreference-v1-core">
+<a href="https://v1-20.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#typedlocalobjectreference-v1-core">
 []Kubernetes core/v1.TypedLocalObjectReference
 </a>
 </em>
@@ -201,7 +201,7 @@ EgressSpec
 <td>
 <code>matches</code><br/>
 <em>
-<a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typedlocalobjectreference-v1-core">
+<a href="https://v1-20.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#typedlocalobjectreference-v1-core">
 []Kubernetes core/v1.TypedLocalObjectReference
 </a>
 </em>


### PR DESCRIPTION
Since OSM leverages client-go v1.20, use the same API
version for doc references to ensure the go client API objects
are compatible with the types referenced in the corresponding
API references.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>