### PR TITLE
docs: deprecate usage of ConfigMap in favor of MeshConfig

### DIFF
--- a/content/docs/tasks_usage/observability/metrics.md
+++ b/content/docs/tasks_usage/observability/metrics.md
@@ -133,7 +133,7 @@ For metrics to be scraped, the following prerequisites must be met:
 
 - The namespace must be a part of the mesh, ie. it must be labeled with the `openservicemesh.io/monitored-by` label with an appropriate mesh name. This can be done using the `osm namespace add` command.
 - A running service able to scrap Prometheus endpoints. OSM provides configuration for an [automatic bringup of Prometheus](#automatic-bring-up); alternatively users can [bring their own Prometheus](#byo-bring-your-own).
-- The `prometheus_scraping` config key in osm-controller's `osm-config` ConfigMap must be set to `"true"`, which is the default configuration.
+- The `prometheusScraping` key in osm-controller's `osm-mesh-config` `MeshConfig` resource must be set to `true`, which is the default configuration.
   - This setting causes the osm-injector to add the following annotations to meshed Pods:
 
     ```yaml

--- a/content/docs/tasks_usage/observability/metrics_manual_guide.md
+++ b/content/docs/tasks_usage/observability/metrics_manual_guide.md
@@ -41,7 +41,7 @@ Let's replace the configuration of `stable-prometheus-server`
 kubectl edit configmap stable-prometheus-server
 ```
 
-Now with your editor of choice, look for the `prometheus.yaml` key entry and replace it with [OSM's scraping config](https://github.com/openservicemesh/osm/blob/release-v0.8/charts/osm/templates/osm-configmap.yaml) (care with yaml formatting):
+Now with your editor of choice, look for the `prometheus.yaml` key entry and replace it with [OSM's scraping config](https://github.com/openservicemesh/osm/blob/release-v0.8/charts/osm/templates/prometheus-configmap.yaml) (proceed with care while formatting the yaml file):
 ```
   (....)
   prometheus.yml: |
@@ -57,14 +57,14 @@ Now with your editor of choice, look for the `prometheus.yaml` key entry and rep
         scheme: https
         tls_config:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          # TODO need to remove this when the CA and SAN match 
+          # TODO need to remove this when the CA and SAN match
           insecure_skip_verify: true
         bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
         metric_relabel_configs:
         - source_labels: [__name__]
           regex: '(apiserver_watch_events_total|apiserver_admission_webhook_rejection_count)'
-          action: keep   
-        relabel_configs: 
+          action: keep
+        relabel_configs:
         - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
           regex: default;kubernetes;https
@@ -93,7 +93,7 @@ Now with your editor of choice, look for the `prometheus.yaml` key entry and rep
         - source_labels: [__name__]
           regex: '(envoy_server_live|envoy_cluster_upstream_rq_xx|envoy_cluster_upstream_cx_active|envoy_cluster_upstream_cx_tx_bytes_total|envoy_cluster_upstream_cx_rx_bytes_total|envoy_cluster_upstream_cx_destroy_remote_with_active_rq|envoy_cluster_upstream_cx_connect_timeout|envoy_cluster_upstream_cx_destroy_local_with_active_rq|envoy_cluster_upstream_rq_pending_failure_eject|envoy_cluster_upstream_rq_pending_overflow|envoy_cluster_upstream_rq_timeout|envoy_cluster_upstream_rq_rx_reset|^osm.*)'
           action: keep
-        relabel_configs: 
+        relabel_configs:
         - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
           action: keep
           regex: true
@@ -146,7 +146,7 @@ Now with your editor of choice, look for the `prometheus.yaml` key entry and rep
           - __meta_kubernetes_pod_controller_name
           action: replace
           regex: ^ReplicaSet;(.*)-[^-]+$
-          target_label: source_workload_name    
+          target_label: source_workload_name
 
       - job_name: 'smi-metrics'
         kubernetes_sd_configs:
@@ -256,7 +256,7 @@ Now with your editor of choice, look for the `prometheus.yaml` key entry and rep
         metric_relabel_configs:
         - source_labels: [__name__]
           regex: '(container_cpu_usage_seconds_total|container_memory_rss)'
-          action: keep   
+          action: keep
         relabel_configs:
         - action: labelmap
           regex: __meta_kubernetes_node_label_(.+)
@@ -274,7 +274,7 @@ After this step, Prometheus should already be able to scrape the mesh and API en
 export POD_NAME=$(kubectl get pods --namespace <promNamespace> -l "app=prometheus,component=server" -o jsonpath="{.items[0].metadata.name}")
 kubectl --namespace <promNamespace> port-forward $POD_NAME 9090
 ```
-And followingly access locally through `http://localhost:9090/targets`. 
+And followingly access locally through `http://localhost:9090/targets`.
 
 Here you should see most of the endpoints connected, up and running for scrape.
 
@@ -320,7 +320,7 @@ OSM Dashboards are available both through:
 - [our repository](https://github.com/openservicemesh/osm/tree/main/charts/osm/grafana), and are importable as json blobs through the web admin portal
 - or [online at Grafana.com](https://grafana.com/grafana/dashboards/14145)
 
-To import a dashboard, look for the `+` sign on the left menu and select `import`. 
+To import a dashboard, look for the `+` sign on the left menu and select `import`.
 You can directly import dashboard by their ID on `Grafana.com`. For example, our `OSM Mesh Details` dashboard uses id `14145`, you can use the ID directly on the form and click `load`:
 
 <p align="center">

--- a/content/docs/tasks_usage/traffic_management/egress.md
+++ b/content/docs/tasks_usage/traffic_management/egress.md
@@ -31,9 +31,9 @@ Egress can be enabled during OSM install or post install. When egress is enabled
 
 2. After OSM has been installed:
 
-	`osm-controller` retrieves the egress configuration from the `osm-config` ConfigMap in its namespace (`osm-system` by default). Use `osm mesh upgrade` to set `egress: "true"` in the `osm-config` ConfigMap
+	`osm-controller` retrieves the egress configuration from the `osm-mesh-config` `MeshConfig` custom resource in its namespace (`osm-system` by default). Use `kubectl patch` to set `enableEgress` to `true` in the `osm-mesh-config` resource.
 	```bash
-    osm mesh upgrade --enable-egress=true
+  kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enableEgress":true}}}'  --type=merge
 	```
 
 ### Disabling Egress
@@ -45,10 +45,10 @@ Similar to enabling egress, egress can be disabled during OSM install or post in
 	```
 
 2. After OSM has been installed:
-	Use `osm mesh upgrade` to set `egress: "false"` in the `osm-config` ConfigMap
+	Use `kubectl patch` to set `enableEgress` to `false` in the `osm-mesh-config` resource.
 	```bash
-    osm mesh upgrade --enable-egress=false
-    ```
+  kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enableEgress":false}}}'  --type=merge
+  ```
 
 With egress disabled, traffic from pods within the mesh will not be able to access external services outside the cluster.
 
@@ -106,11 +106,11 @@ The following demo shows a `curl` client making HTTPS requests to the external `
 
     A `200 OK` response indicates the HTTPS request from the `curl` client to the `httpbin.org` website was successful.
 
-1. Confirm the HTTPS requests fail when egress is disabled.
+1. Confirm the HTTPS requests fail when mesh-wide egress is disabled.
 
     ```bash
     # Assumes OSM is installed in the osm-system namespace
-    kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"egress":"false"}}' --type=merge
+    kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enableEgress":false}}}'  --type=merge
     ```
 
     ```console

--- a/content/docs/tasks_usage/traffic_management/ingress.md
+++ b/content/docs/tasks_usage/traffic_management/ingress.md
@@ -49,21 +49,20 @@ Other ingress controllers might also work as long as they use the Kubernetes Ing
 
 ### Enabling HTTP or HTTPS Ingress
 
-By default, OSM configures HTTP as the backend protocol for services when an ingress resource is applied with a backend service that belongs to the mesh. A mesh-wide configuration setting in OSM's `osm-config` ConfigMap enables configuring ingress with the backend protocol to be HTTPS.
+By default, OSM configures HTTP as the backend protocol for services when an ingress resource is applied with a backend service that belongs to the mesh. A mesh-wide configuration setting in OSM's `osm-mesh-config` `MeshConfig` custom resource enables configuring ingress with the backend protocol to be HTTPS.
 
 #### HTTP ingress
 HTTP based ingress is provisioned in OSM by default.
 
 #### HTTPS ingress
-HTTPs Ingress is disabled by default when OSM is installed. However, HTTPS ingress can be enabled by updating the `osm-config` ConfigMap in `osm-controller`'s namespace (`osm-system` by default).
+HTTPs Ingress is disabled by default when OSM is installed. However, HTTPS ingress can be enabled by updating the `osm-mesh-config` custom resource in `osm-controller`'s namespace (`osm-system` by default).
 
-Patch the ConfigMap by setting use_https_ingress: "true".
+Patch the `osm-mesh-config` resource to set `useHTTPSIngress` to `true`.
 
 ```bash
 # Replace osm-system with osm-controller's namespace if using a non default namespace
-kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"use_https_ingress":"true"}}' --type=merge
+kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"useHTTPSIngress":true}}}'  --type=merge
 ```
-> Note: Changes made with `kubectl patch` are not preserved across release upgrades. To make this change persistent between upgrades, use `osm mesh upgrade`. See `osm mesh upgrade --help` for more details.
 
 > Note: Enabling HTTPS ingress will disable HTTP ingress.
 
@@ -82,7 +81,7 @@ Patch the ConfigMap by setting use_https_ingress: "false".
 
 ```bash
 # Replace osm-system with osm-controller's namespace if using a non default namespace
-kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"use_https_ingress":"false"}}' --type=merge
+kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"useHTTPSIngress":false}}}'  --type=merge
 ```
 
 ## How it works

--- a/content/docs/tasks_usage/traffic_management/permissive_traffic_policy_mode.md
+++ b/content/docs/tasks_usage/traffic_management/permissive_traffic_policy_mode.md
@@ -30,7 +30,8 @@ osm install --set OpenServiceMesh.enablePermissiveTrafficPolicy=true
 
 After OSM has been installed:
 ```bash
-osm mesh upgrade --enable-permissive-traffic-policy=true
+# Assumes OSM is installed in the osm-system namespace
+kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enablePermissiveTrafficPolicyMode":true}}}'  --type=merge
 ```
 
 ### Disabling permissive traffic policy mode
@@ -44,7 +45,8 @@ osm install --set OpenServiceMesh.enablePermissiveTrafficPolicy=false
 
 After OSM has been installed:
 ```bash
-osm mesh upgrade --enable-permissive-traffic-policy=false
+# Assumes OSM is installed in the osm-system namespace
+kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enablePermissiveTrafficPolicyMode":false}}}'  --type=merge
 ```
 
 ## How it works
@@ -129,7 +131,7 @@ The following demo shows an HTTP `curl` client making HTTP requests to the `http
 
     ```bash
     # Assumes OSM is installed in the osm-system namespace
-    kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"permissive_traffic_policy_mode":"false"}}' --type=merge
+    kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enablePermissiveTrafficPolicyMode":false}}}'  --type=merge
     ```
 
     ```console

--- a/content/docs/troubleshooting/observability/prometheus.md
+++ b/content/docs/troubleshooting/observability/prometheus.md
@@ -72,11 +72,11 @@ If Prometheus is found not to be scraping metrics for any Pods, perform the foll
 
 1. Verify Prometheus scraping is enabled.
 
-    Ensure the `prometheus_scraping` key in the `osm-config` ConfigMap is set to `true`:
+    Ensure the `prometheusScraping` key in the `osm-mesh-config` resource is set to `true`:
 
     ```console
     $ # Assuming OSM is installed in the osm-system namespace:
-    $ kubectl get configmap -n osm-system osm-config -o jsonpath='{.data.prometheus_scraping}'
+    $ kubectl get meshconfig osm-mesh-config -n osm-system -o jsonpath='{.spec.observability.prometheusScraping}{"\n"}'
     true
     ```
 
@@ -84,8 +84,8 @@ If Prometheus is found not to be scraping metrics for any Pods, perform the foll
 
     ```console
     $ # Assuming OSM is installed in the osm-system namespace:
-    $ kubectl patch configmap -n osm-system osm-config --type=merge -p '{"data": {"prometheus_scraping": "true"}}'
-    configmap/osm-config patched
+    $ kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"observability":{"prometheusScraping":true}}}'  --type=merge
+    meshconfig.config.openservicemesh.io/osm-mesh-config patched
     ```
 
 1. Verify the intended namespaces have been enrolled in metrics collection.

--- a/content/docs/troubleshooting/observability/tracing.md
+++ b/content/docs/troubleshooting/observability/tracing.md
@@ -6,30 +6,27 @@ type: docs
 
 # When tracing is not working as expected
 
-## 1. Errors enabling tracing
-If you face issues with using `osm mesh upgrade` to enable tracing on a running OSM instance, troubleshoot [here](https://docs.openservicemesh.io/docs/troubleshooting/cli/mesh_upgrade/)
-
-## 2. Verify that tracing is enabled
-Ensure the `tracing_enable` key in the `osm-config` ConfigMap is set to `true`:
+## 1. Verify that tracing is enabled
+Ensure the `enable` key in the `tracing` configuration is set to `true`:
 ```bash
-kubectl get configmap -n osm-system osm-config -o json | jq '.data.tracing_enable'
-"true"
+kubectl get meshconfig osm-mesh-config -n osm-system -o jsonpath='{.spec.observability.tracing.enable}{"\n"}'
+true
 ```
 
-## 3. Verify the tracing values being set are as expected 
-If tracing is enabled, you can verify the specific `tracing_address`, `tracing_port` and `tracing_endpoint` being used for tracing in the ConfigMap:
+## 2. Verify the tracing values being set are as expected
+If tracing is enabled, you can verify the specific `address`, `port` and `endpoint` being used for tracing in the `osm-mesh-config` resource:
 ```bash
-kubectl get configmap osm-config -n osm-system -o json | jq '.data'
+kubectl get meshconfig osm-mesh-config -n osm-system -o jsonpath='{.spec.observability.tracing}{"\n"}'
 ```
-To verify that the Envoys point to the FQDN you intend to use, check the `tracing_address` value.
+To verify that the Envoys point to the FQDN you intend to use, check the value for the `address` key.
 
-## 4. Verify the tracing values being used are as expected
+## 3. Verify the tracing values being used are as expected
 To dig one level deeper, you may also check whether the values set by the ConfigMap are being correctly used. Use the command below to get the config dump of the pod in question and save the output in a file.
 ```bash
 osm proxy get config_dump -n <pod-namespace> <pod-name> > <file-name>
 ```
 Open the file in your favorite text editor and search for `envoy-tracing-cluster`. You should be able to see the tracing values in use. Example output for the bookbuyer pod:
-```json
+```console
 "name": "envoy-tracing-cluster",
       "type": "LOGICAL_DNS",
       "connect_timeout": "1s",
@@ -48,7 +45,7 @@ Open the file in your favorite text editor and search for `envoy-tracing-cluster
         [...]
 ```
 
-## 5. Verify that the OSM Controller was installed with Jaeger automatically deployed [optional]
+## 4. Verify that the OSM Controller was installed with Jaeger automatically deployed [optional]
 If you used automatic bring-up, you can additionally check for the Jaeger service and Jaeger deployment:
 ```bash
 # Assuming OSM is installed in the osm-system namespace:
@@ -66,7 +63,7 @@ NAME     READY   UP-TO-DATE   AVAILABLE   AGE
 jaeger   1/1     1            1           27m
 ```
 
-## 6. Verify Jaeger pod readiness, responsiveness and health
+## 5. Verify Jaeger pod readiness, responsiveness and health
 Check if the Jaeger pod is running in the namespace you have deployed it in:
 > The commands below are specific to OSM's automatic deployment of Jaeger; substitute namespace and label values for your own tracing instance as applicable:
 ```bash

--- a/content/docs/troubleshooting/traffic/egress.md
+++ b/content/docs/troubleshooting/traffic/egress.md
@@ -9,11 +9,11 @@ aliases: ["egress.md"]
 
 ### 1. Confirm egress is enabled
 
-Confirm egress is enabled by verifying the value for the `egress` key in the `osm-config` ConfigMap. `osm-config` ConfigMap resides in the namespace OSM control plane namespace, `osm-system` by default.
+Confirm egress is enabled by verifying the value for the `enableEgress` key in the `osm-mesh-config` `MeshConfig` custom resource. `osm-mesh-config` resides in the namespace OSM control plane namespace, `osm-system` by default.
 
 ```console
 # Returns true if egress is enabled
-$ kubectl get configmap -n osm-system osm-config -o jsonpath='{.data.egress}{"\n"}'
+$ kubectl get meshconfig osm-mesh-config -n osm-system -o jsonpath='{.spec.traffic.enableEgress}{"\n"}'
 true
 ```
 
@@ -34,9 +34,3 @@ Errors will be logged with the `level` key in the log message set to `error`:
 ### 3. Confirm the Envoy configuration
 
 Confirm the Envoy proxy configuration on the client has a default egress filter chain on the outbound listener. Refer to the [sample configurations](../../../tasks_usage/traffic_management/egress#envoy-configurations) to verify that the client is configured to have outbound access to external destinations.
-
-## When the setting needs to be persisted across upgrades
-
-While the `osm-config` ConfigMap can be directly updated using the `kubectl patch` command, to persist configuration changes across upgrades, it is recommended to always use `osm mesh upgrade` CLI command to update the mesh configuration.
-
-Refer to the [configuring egress](../../../tasks_usage/traffic_management/egress#configuring-egress) section to enable or disable egress.

--- a/content/docs/troubleshooting/traffic/ingress.md
+++ b/content/docs/troubleshooting/traffic/ingress.md
@@ -7,27 +7,26 @@ aliases: ["ingress.md"]
 
 ## When Ingress is not working as expected
 
-### 1. Confirm global ingress configuration is set as expected. 
+### 1. Confirm global ingress configuration is set as expected.
 
 ```console
 # Returns true if HTTPS ingress is enabled
-$ kubectl get ConfigMap osm-config -n osm-system -p jsonpath='{.data.use_https_ingress}{"\n"}'
+$ kubectl get meshconfig osm-mesh-config -n osm-system -o jsonpath='{.spec.traffic.useHTTPSIngress}{"\n"}'
+false
 ```
 
-If the output of this command is `false` this means that HTTP ingress is enabled and HTTPS ingress is disabled. To disable HTTP ingress and enable HTTPS ingress, use the following command: 
+If the output of this command is `false` this means that HTTP ingress is enabled and HTTPS ingress is disabled. To disable HTTP ingress and enable HTTPS ingress, use the following command:
 
 ```bash
 # Replace osm-system with osm-controller's namespace if using a non default namespace
-kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"use_https_ingress":"true"}}' --type=merge
+kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"useHTTPSIngress":true}}}'  --type=merge
 ```
-> Note: Changes made with `kubectl patch` are not preserved across release upgrades. To make this change persistent between upgrades, use `osm mesh upgrade`. See `osm mesh upgrade --help` for more details.
 
-
-Likewise, to enable HTTP ingress and disable HTTPS ingress, run: 
+Likewise, to enable HTTP ingress and disable HTTPS ingress, run:
 
 ```bash
 # Replace osm-system with osm-controller's namespace if using a non default namespace
-kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"use_https_ingress":"false"}}' --type=merge
+kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"useHTTPSIngress":false}}}'  --type=merge
 ```
 
 ### 2. Inspect OSM controller logs for errors

--- a/content/docs/troubleshooting/traffic/iptables_redirection.md
+++ b/content/docs/troubleshooting/traffic/iptables_redirection.md
@@ -59,21 +59,21 @@ By default, all traffic using TCP as the underlying transport protocol are redir
 
 If outbound IP ranges are configured to be excluded but being subject to service mesh policies, verify they are configured as expected.
 
-### 1. Confirm outbound IP ranges are correctly configured in the `osm-config` ConfigMap
+### 1. Confirm outbound IP ranges are correctly configured in the `osm-mesh-config` MeshConfig resource
 
 Confirm the outbound IP ranges to be excluded are set correctly:
 
 ```console
 # Assumes OSM is installed in the osm-system namespace
-$ kubectl get configmap -n osm-system osm-config -o jsonpath='{.data.outbound_ip_range_exclusion_list}{"\n"}'
-1.1.1.1/32, 2.2.2.2/24
+$ kubectl get meshconfig osm-mesh-config -n osm-system -o jsonpath='{.spec.traffic.outboundIPRangeExclusionList}{"\n"}'
+["1.1.1.1/32","2.2.2.2/24"]
 ```
 
-The output shows the IP ranges that are excluded from outbound traffic redirection, `1.1.1.1/32 and 2.2.2.2/24` in the example above.
+The output shows the IP ranges that are excluded from outbound traffic redirection, `["1.1.1.1/32","2.2.2.2/24"]` in the example above.
 
 ### 2. Confirm outbound IP ranges are included in init container spec
 
-When outbound IP range exclusions are configured, OSM's `osm-injector` service reads this configuration from the `osm-config` ConfigMap and programs `iptables` rules corresponding to these ranges so that they are excluded from outbound traffic redirection via the Envoy sidecar proxy.
+When outbound IP range exclusions are configured, OSM's `osm-injector` service reads this configuration from the `osm-mesh-config` `MeshConfig` resource and programs `iptables` rules corresponding to these ranges so that they are excluded from outbound traffic redirection via the Envoy sidecar proxy.
 
 Confirm OSM's `osm-init` init container spec has rules corresponding to the configured outbound IP ranges to exclude.
 
@@ -119,17 +119,17 @@ By default, all traffic using TCP as the underlying transport protocol are redir
 
 If outbound ports are configured to be excluded but being subject to service mesh policies, verify they are configured as expected.
 
-### 1. Confirm global outbound ports are correctly configured in the `osm-config` ConfigMap
+### 1. Confirm global outbound ports are correctly configured in the `osm-mesh-config` MeshConfig resource
 
 Confirm the outbound ports to be excluded are set correctly:
 
 ```console
 # Assumes OSM is installed in the osm-system namespace
-$ kubectl get configmap -n osm-system osm-config -o jsonpath='{.data.outbound_port_exclusion_list}{"\n"}'
-6379, 7070
+$ kubectl get meshconfig osm-mesh-config -n osm-system -o jsonpath='{.spec.traffic.outboundPortExclusionList}{"\n"}'
+[6379,7070]
 ```
 
-The output shows the ports that are excluded from outbound traffic redirection, `6379 and 7070` in the example above.
+The output shows the ports that are excluded from outbound traffic redirection, `[6379,7070]` in the example above.
 
 ### 2. Confirm pod level outbound ports are correctly annotated on the pod
 
@@ -144,7 +144,7 @@ The output shows the ports that are excluded from outbound traffic redirection o
 
 ### 3. Confirm outbound ports are included in init container spec
 
-When outbound port exclusions are configured, OSM's `osm-injector` service reads this configuration from the `osm-config` ConfigMap and from the annotations on the pod, and programs `iptables` rules corresponding to these ranges so that they are excluded from outbound traffic redirection via the Envoy sidecar proxy.
+When outbound port exclusions are configured, OSM's `osm-injector` service reads this configuration from the `osm-mesh-config` `MeshConfig` resource and from the annotations on the pod, and programs `iptables` rules corresponding to these ranges so that they are excluded from outbound traffic redirection via the Envoy sidecar proxy.
 
 Confirm OSM's `osm-init` init container spec has rules corresponding to the configured outbound ports to exclude.
 

--- a/content/docs/troubleshooting/traffic/permissive_traffic_policy_mode.md
+++ b/content/docs/troubleshooting/traffic/permissive_traffic_policy_mode.md
@@ -9,11 +9,11 @@ aliases: ["permissive_traffic_policy_mode.md"]
 
 ### 1. Confirm Permissive traffic policy mode is enabled
 
-Confirm permissive traffic policy mode is enabled by verifying the value for the `permissive_traffic_policy_mode` key in the `osm-config` ConfigMap. `osm-config` ConfigMap resides in the namespace OSM control plane namespace, `osm-system` by default.
+Confirm permissive traffic policy mode is enabled by verifying the value for the `enablePermissiveTrafficPolicyMode` key in the `osm-mesh-config` custom resource. `osm-mesh-config` ConfigMap resides in the namespace OSM control plane namespace, `osm-system` by default.
 
 ```console
 # Returns true if permissive traffic policy mode is enabled
-$ kubectl get configmap -n osm-system osm-config -o jsonpath='{.data.permissive_traffic_policy_mode}{"\n"}'
+$ kubectl get meshconfig osm-mesh-config -n osm-system -o jsonpath='{.spec.traffic.enablePermissiveTrafficPolicyMode}{"\n"}'
 true
 ```
 
@@ -34,9 +34,3 @@ Errors will be logged with the `level` key in the log message set to `error`:
 ### 3. Confirm the Envoy configuration
 
 Confirm the Envoy proxy configuration on the client and server pods are allowing the client to access the server. Refer to the [sample configurations](../../../tasks_usage/traffic_management/permissive_traffic_policy_mode#envoy-configurations) to verify that the client has valid routes programmed to access the server.
-
-## When the setting needs to be persisted across upgrades
-
-While the `osm-config` ConfigMap can be directly updated using the `kubectl patch` command, to persist configuration changes across upgrades, it is recommended to always use `osm mesh upgrade` CLI command to update the mesh configuration.
-
-Refer to the [configuring permissive traffic policy mode](../../../tasks_usage/traffic_management/permissive_traffic_policy_mode#configuring-permissive-traffic-policy-mode) section to enable or disable permissive traffic policy mode.


### PR DESCRIPTION
openservicemesh/osm#2738 deprecated the usage of osm-config
ConfigMap for dynamic control plane config updates. The
osm-mesh-config MeshConfig custom resource is used to store
and serve dynamic config for the control plane.

This change updates the docs to reflect the above change.
Notably, it does the following:

- Updates documentation pertaining to the use of osm-config
  ConfigMap for configs stored in the osm-mesh-config resource.

- Updates documentation pertaining to the use of the `osm mesh
  upgrade` command to update such config. This is no longer
  necessary to preserve values during an upgrade since the
  MeshConfig resouce is not updated by OSM during an upgrade.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>