### PR TITLE
docs/traffic: document egress policies usage

### DIFF
--- a/content/docs/tasks_usage/traffic_management/demos/_index.md
+++ b/content/docs/tasks_usage/traffic_management/demos/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Traffic Management Demos"
+description: "OSM's traffic management stack manages traffic flowing between applications in the mesh, access to applications from outside the cluster using Ingress, and access to external applications using Egress. The demos provide a good starting point to get familiar with these features."
+type: docs
+---
+
+## Table of Contents
+- [Ingress demo with Azure Application Gateway](./azure_application_gateway_ingress_demo)
+- [Ingress demo with Gloo Edge API Gateway](./gloo_edge_ingress_demo)
+- [Egress demo using OSM's Egress Policy](./egress_policy_demo)

--- a/content/docs/tasks_usage/traffic_management/demos/azure_application_gateway_ingress_demo.md
+++ b/content/docs/tasks_usage/traffic_management/demos/azure_application_gateway_ingress_demo.md
@@ -2,10 +2,9 @@
 title: "Ingress with Azure Application Gateway Demo"
 description: "Exposing services outside the cluster using Azure Application Gateway Ingress Controller"
 type: docs
-aliases: ["azure_application_gateway_ingress_demo.md"]
 ---
 
-The OSM ingress guide with Azure Application Gateway is a short demo on exposing HTTP routes on services within the mesh externally using the Azure Application Gateway ingress controller. 
+The OSM ingress guide with Azure Application Gateway is a short demo on exposing HTTP routes on services within the mesh externally using the Azure Application Gateway ingress controller.
 
 ## Sample demo
 

--- a/content/docs/tasks_usage/traffic_management/demos/egress_policy_demo.md
+++ b/content/docs/tasks_usage/traffic_management/demos/egress_policy_demo.md
@@ -1,0 +1,190 @@
+---
+title: "Egress Policy Demo"
+description: "Accesing external services using Egress policies."
+type: docs
+---
+
+This guide demoes a client within the service mesh accessing destinations external to the mesh using OSM's Egress policy API.
+
+## Prerequisites
+1. Install OSM with the Egress policy feature enabled:
+    ```bash
+    osm install --set=OpenServiceMesh.featureFlags.enableEgressPolicy=true
+    ```
+
+1. Deploy the `curl` client into the `curl` namespace after enrolling its namespace to the mesh.
+    ```bash
+    # Create the curl namespace
+    kubectl create namespace curl
+
+    # Add the namespace to the mesh
+    osm namespace add curl
+
+    # Deploy curl client in the curl namespace
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/main/docs/example/manifests/samples/curl/curl.yaml -n curl
+    ```
+
+    Confirm the `curl` client pod is up and running.
+
+    ```console
+    $ kubectl get pods -n curl
+    NAME                    READY   STATUS    RESTARTS   AGE
+    curl-54ccc6954c-9rlvp   2/2     Running   0          20s
+    ```
+
+## HTTP Egress
+
+1. Confirm the `curl` client is unable make the HTTP request `http://httpbin.org:80/get` to the `httpbin.org` website on port `80`.
+    ```console
+    $ kubectl exec $(kubectl get pod -n curl -l app=curl -o jsonpath='{.items..metadata.name}') -n curl -c curl -- curl -sI http://httpbin.org:80/get
+    command terminated with exit code 7
+    ```
+
+1. Apply an Egress policy to allow the `curl` client's ServiceAccount to access the `httpbin.org` website on port `80` serving the `http` protocol.
+    ```bash
+    kubectl apply -f - <<EOF
+    kind: Egress
+    apiVersion: policy.openservicemesh.io/v1alpha1
+    metadata:
+      name: httpbin-80
+      namespace: curl
+    spec:
+      sources:
+      - kind: ServiceAccount
+        name: curl
+        namespace: curl
+      hosts:
+      - httpbin.org
+      ports:
+      - number: 80
+        protocol: http
+    EOF
+    ```
+
+1. Confirm the `curl` client is able to make successful HTTP requests to `http://httpbin.org:80/get`.
+    ```console
+    $ kubectl exec $(kubectl get pod -n curl -l app=curl -o jsonpath='{.items..metadata.name}') -n curl -c curl -- curl -sI http://httpbin.org:80/get
+    HTTP/1.1 200 OK
+    date: Thu, 13 May 2021 21:49:35 GMT
+    content-type: application/json
+    content-length: 335
+    server: envoy
+    access-control-allow-origin: *
+    access-control-allow-credentials: true
+    x-envoy-upstream-service-time: 168
+    ```
+
+1. Confirm the `curl` client can no longer make successful HTTP requests to `http://httpbin.org:80/get` when the above policy is removed.
+    ```bash
+    kubectl delete egress httpbin-80 -n curl
+    ```
+
+    ```console
+    $ kubectl exec $(kubectl get pod -n curl -l app=curl -o jsonpath='{.items..metadata.name}') -n curl -c curl -- curl -sI http://httpbin.org:80/get
+    command terminated with exit code 7
+    ```
+
+## HTTPS Egress
+
+Since HTTPS traffic is encrypted with TLS, OSM routes HTTPS based traffic by proxying it to its original destination as a TCP stream. The Server Name Indication (SNI) indicated by the HTTPS client application in the TLS handshake is matched against hosts specified in the Egress policy.
+
+1. Confirm the `curl` client is unable make the HTTPS request `https://httpbin.org:443/get` to the `httpbin.org` website on port `443`.
+    ```console
+    $ kubectl exec $(kubectl get pod -n curl -l app=curl -o jsonpath='{.items..metadata.name}') -n curl -c curl -- curl -sI https://httpbin.org:443/get
+    command terminated with exit code 7
+    ```
+
+1. Apply an Egress policy to allow the `curl` client's ServiceAccount to access the `httpbin.org` website on port `443` serving the `https` protocol.
+    ```bash
+    kubectl apply -f - <<EOF
+    kind: Egress
+    apiVersion: policy.openservicemesh.io/v1alpha1
+    metadata:
+      name: httpbin-443
+      namespace: curl
+    spec:
+      sources:
+      - kind: ServiceAccount
+        name: curl
+        namespace: curl
+      hosts:
+      - httpbin.org
+      ports:
+      - number: 443
+        protocol: https
+    EOF
+    ```
+
+1. Confirm the `curl` client is able to make successful HTTPS requests to `https://httpbin.org:443/get`.
+    ```console
+    $ kubectl exec $(kubectl get pod -n curl -l app=curl -o jsonpath='{.items..metadata.name}') -n curl -c curl -- curl -sI https://httpbin.org:443/get
+    HTTP/2 200
+    date: Thu, 13 May 2021 22:09:36 GMT
+    content-type: application/json
+    content-length: 260
+    server: gunicorn/19.9.0
+    access-control-allow-origin: *
+    access-control-allow-credentials: true
+    ```
+
+1. Confirm the `curl` client can no longer make successful HTTPS requests to `https://httpbin.org:443/get` when the above policy is removed.
+    ```bash
+    kubectl delete egress httpbin-443 -n curl
+    ```
+    ```console
+    $ kubectl exec $(kubectl get pod -n curl -l app=curl -o jsonpath='{.items..metadata.name}') -n curl -c curl -- curl -sI https://httpbin.org:443/get
+    command terminated with exit code 7
+    ```
+
+## TCP Egress
+
+TCP based Egress traffic is matched against the destination port and IP address ranges specified in an egress policy. If an IP address range is not specified, traffic will be matched only based on the destination port.
+
+1. Confirm the `curl` client is unable make the HTTPS request `https://openservicemesh.io:443` to the `openservicemesh.io` website on port `443`. Since HTTPS uses TCP as the underlying transport protocol, TCP based routing should implicitly enable access to any HTTP(s) host on the specified port.
+    ```console
+    $ kubectl exec $(kubectl get pod -n curl -l app=curl -o jsonpath='{.items..metadata.name}') -n curl -c curl -- curl -sI https://openservicemesh.io:443
+    command terminated with exit code 7
+    ```
+
+1. Apply an Egress policy to allow the `curl` client's ServiceAccount to access the any destination on port `443` serving the `tcp` protocol.
+    ```bash
+    kubectl apply -f - <<EOF
+    kind: Egress
+    apiVersion: policy.openservicemesh.io/v1alpha1
+    metadata:
+      name: tcp-443
+      namespace: curl
+    spec:
+      sources:
+      - kind: ServiceAccount
+        name: curl
+        namespace: curl
+      ports:
+      - number: 443
+        protocol: tcp
+    EOF
+    ```
+
+1. Confirm the `curl` client is able to make successful HTTPS requests to `https://openservicemesh.io:443`.
+    ```console
+    $ kubectl exec $(kubectl get pod -n curl -l app=curl -o jsonpath='{.items..metadata.name}') -n curl -c curl -- curl -sI https://openservicemesh.io:443
+    HTTP/2 200
+    cache-control: public, max-age=0, must-revalidate
+    content-length: 0
+    content-type: text/html; charset=UTF-8
+    date: Thu, 13 May 2021 22:35:07 GMT
+    etag: "353ebaaf9573718bd1df6b817a472e47-ssl"
+    strict-transport-security: max-age=31536000
+    age: 0
+    server: Netlify
+    x-nf-request-id: 35a4f2dc-5356-45dc-9208-63e6fa162e0f-3350874
+    ```
+
+1. Confirm the `curl` client can no longer make successful HTTPS requests to `https://openservicemesh.io:443` when the above policy is removed.
+    ```bash
+    kubectl delete egress tcp-443 -n curl
+    ```
+    ```console
+    $ kubectl exec $(kubectl get pod -n curl -l app=curl -o jsonpath='{.items..metadata.name}') -n curl -c curl -- curl -sI https://openservicemesh.io:443
+    command terminated with exit code 7
+    ```

--- a/content/docs/tasks_usage/traffic_management/demos/gloo_edge_ingress_demo.md
+++ b/content/docs/tasks_usage/traffic_management/demos/gloo_edge_ingress_demo.md
@@ -2,10 +2,9 @@
 title: "Ingress with Gloo Edge Ingress Demo"
 description: "Exposing services outside the cluster using Gloo Edge Ingress Controller"
 type: docs
-aliases: ["gloo_edge_ingress_demo.md"]
 ---
 
-The OSM ingress guide with Gloo API Gateway is a short demo on exposing HTTP routes on services within the mesh externally using the Gloo Edge ingress controller. 
+The OSM ingress guide with Gloo API Gateway is a short demo on exposing HTTP routes on services within the mesh externally using the Gloo Edge ingress controller.
 
 ## Sample demo
 
@@ -18,7 +17,7 @@ The following demo sends a request from an external IP to a httpbin service insi
     glooctl install ingress
     ```
 
-    Verify that the pods in the gloo-system namespace is up and running: 
+    Verify that the pods in the gloo-system namespace is up and running:
 
     ```console
     $ kubectl get pods -n gloo-system
@@ -115,7 +114,7 @@ The following demo sends a request from an external IP to a httpbin service insi
     httpbin-ingress   <none>   httpbin.httpbin.svc.cluster.local   52.234.160.38   80      152m
     ```
 
-1. Configure the `Upstream` object to use OSM's root ca bundle: 
+1. Configure the `Upstream` object to use OSM's root ca bundle:
 
     ```yaml
     apiVersion: gloo.solo.io/v1

--- a/content/docs/tasks_usage/traffic_management/egress.md
+++ b/content/docs/tasks_usage/traffic_management/egress.md
@@ -5,9 +5,9 @@ type: docs
 aliases: ["egress.md"]
 ---
 
-# Allowing access to the Internet and out-of-mesh services (egress)
+# Allowing access to the Internet and out-of-mesh services (Egress)
 
-This document describes the steps required to enable access to the Internet and services external to the service mesh, sometimes referred to as `egress` traffic.
+This document describes the steps required to enable access to the Internet and services external to the service mesh, referred to as `Egress` traffic.
 
 OSM redirects all outbound traffic from a pod within the mesh to the pod's sidecar proxy. Outbound traffic can be classified into two categories:
 
@@ -19,59 +19,64 @@ While in-mesh traffic is routed based on L7 traffic policies, egress traffic is 
 
 ## Configuring Egress
 
-Enabling egress is done via a global setting. The setting is toggled on or off and affects all services in the mesh. Egress is disabled by default when OSM is installed.
+There are two mechanisms to configure Egress:
 
-### Enabling egress
-Egress can be enabled during OSM install or post install. When egress is enabled, outbound traffic from pods are allowed to egress the pod as long as the traffic does not match in-mesh traffic policies that otherwise deny the traffic.
+1. Using a mesh-wide global setting: the setting is toggled on or off and affects all pods in the mesh, enabling which allows traffic destined to destinations outside the mesh to egress the pod.
+2. Using the Egress policy API: to provide fine grained access control over external traffic
+
+
+## Configuring mesh-wide Egress
+
+### Enabling mesh-wide Egress to external destinations
+Egress can be enabled mesh-wide during OSM install or post install. When egress is enabled mesh-wide, outbound traffic from pods are allowed to egress the pod as long as the traffic does not match in-mesh traffic policies that otherwise deny the traffic.
 
 1. During OSM install (default `OpenServiceMesh.enableEgress=false`):
-	```bash
-	osm install --set OpenServiceMesh.enableEgress=true
-	```
+    ```bash
+    osm install --set OpenServiceMesh.enableEgress=true
+    ```
 
 2. After OSM has been installed:
 
 	`osm-controller` retrieves the egress configuration from the `osm-mesh-config` `MeshConfig` custom resource in its namespace (`osm-system` by default). Use `kubectl patch` to set `enableEgress` to `true` in the `osm-mesh-config` resource.
-	```bash
-  kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enableEgress":true}}}'  --type=merge
-	```
+    ```bash
+    kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enableEgress":true}}}'c--type=merge
+    ```
 
-### Disabling Egress
-Similar to enabling egress, egress can be disabled during OSM install or post install.
+### Disabling mesh-wide Egress to external destinations
+Similar to enabling egress, mesh-wide egress can be disabled during OSM install or post install.
 
 1. During OSM install:
-	```bash
-	osm install --set OpenServiceMesh.enableEgress=false
-	```
+    ```bash
+    osm install --set OpenServiceMesh.enableEgress=false
+    ```
 
 2. After OSM has been installed:
 	Use `kubectl patch` to set `enableEgress` to `false` in the `osm-mesh-config` resource.
-	```bash
-  kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enableEgress":false}}}'  --type=merge
-  ```
+    ```bash
+    kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enableEgress":false}}}'  --type=merge
+    ```
 
 With egress disabled, traffic from pods within the mesh will not be able to access external services outside the cluster.
 
-## How it works
-When egress is enabled globally in the mesh, OSM controller programs every Envoy proxy sidecar in the mesh with a wildcard rule that matches outbound destinations that do not correspond to in-mesh services. The wildcard rule that matches such external traffic simply proxies the traffic as is to its original destination without subjecting them to L4 or L7 traffic policies.
+### How it works
+When egress is enabled mesh-wide, OSM controller programs every Envoy proxy sidecar in the mesh with a wildcard rule that matches outbound destinations that do not correspond to in-mesh services. The wildcard rule that matches such external traffic simply proxies the traffic as is to its original destination without subjecting them to L4 or L7 traffic policies.
 
 OSM supports egress for traffic that uses TCP as the underlying transport. This includes raw TCP traffic, HTTP, HTTPS, gRPC etc.
 
-Since egress is a global setting and operates as a passthrough to unknown destinations, fine grained access control (such as applying TCP or HTTP routing policies) over egress traffic is not currently supported.
+Since mesh-wide egress is a global setting and operates as a passthrough to unknown destinations, fine grained access control (such as applying TCP or HTTP routing policies) over egress traffic is not possible.
 
-## Sample demo
+### Sample demo with mesh-wide Egress
 
-### HTTP(S) traffic with egress
+#### HTTP(S) traffic with mesh-wide Egress
 
-The following demo shows a `curl` client making HTTPS requests to the external `httpbin.org` website using egress.
+The following demo shows a `curl` client making HTTPS requests to the external `httpbin.org` website using Egress.
 
-1. Install OSM with egress enabled.
+1. Install OSM with global egress enabled.
     ```bash
     osm install --set OpenServiceMesh.enableEgress=true
     ```
 
 1. Deploy the `curl` client into the `curl` namespace after enrolling its namespace to the mesh.
-
     ```bash
     # Create the curl namespace
     kubectl create namespace curl
@@ -80,7 +85,7 @@ The following demo shows a `curl` client making HTTPS requests to the external `
     osm namespace add curl
 
     # Deploy curl client in the curl namespace
-    kubectl apply -f docs/example/manifests/samples/curl/curl.yaml -n curl
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/main/docs/example/manifests/samples/curl/curl.yaml -n curl
     ```
 
     Confirm the `curl` client pod is up and running.
@@ -92,34 +97,31 @@ The following demo shows a `curl` client making HTTPS requests to the external `
     ```
 
 1. Confirm the `curl` client is able to make successful HTTPS requests to the `httpbin.org` website on port `443`.
-
     ```console
     $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I https://httpbin.org:443
-	HTTP/2 200
-	date: Tue, 16 Mar 2021 22:19:00 GMT
-	content-type: text/html; charset=utf-8
-	content-length: 9593
-	server: gunicorn/19.9.0
-	access-control-allow-origin: *
-	access-control-allow-credentials: true
+    HTTP/2 200
+    date: Tue, 16 Mar 2021 22:19:00 GMT
+    content-type: text/html; charset=utf-8
+    content-length: 9593
+    server: gunicorn/19.9.0
+    access-control-allow-origin: *
+    access-control-allow-credentials: true
     ```
 
     A `200 OK` response indicates the HTTPS request from the `curl` client to the `httpbin.org` website was successful.
 
 1. Confirm the HTTPS requests fail when mesh-wide egress is disabled.
-
     ```bash
     # Assumes OSM is installed in the osm-system namespace
     kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enableEgress":false}}}'  --type=merge
     ```
-
     ```console
     $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I https://httpbin.org:443
-	curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to httpbin.org:443
-	command terminated with exit code 35
+	  curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to httpbin.org:443
+	  command terminated with exit code 35
     ```
 
-## Envoy configurations
+### Envoy configurations
 
 When egress is globally enabled in the mesh, OSM controller programs each Envoy proxy sidecar to match external or unknown destinations using a default filter chain on the outbound listener configuration. The default filter chain is named `outbound-egress-filter-chain` as seen in the below configuration snippet. Any traffic that matches the default egress filter chain on the outbound listener is proxied to its original destination via the `passthrough-outbound` cluster.
 
@@ -161,3 +163,12 @@ When egress is globally enabled in the mesh, OSM controller programs each Envoy 
   }
 }
 ```
+
+## Configuring Egress policies
+
+OSM supports configuring fine grained policies for traffic destined to external endpoints using its Egress policy API. To use this feature, enable it during install:
+```bash
+osm install --set=OpenServiceMesh.featureFlags.enableEgressPolicy=true
+```
+
+Refer to the [Egress policy v1alpha1 API documentation](/docs/apidocs/policy/v1alpha1) to configure egress policies and [sample demos using the Egress policy API](/docs/tasks_usage/traffic_management/demos/egress_policy_demo).

--- a/content/docs/tasks_usage/traffic_management/ingress.md
+++ b/content/docs/tasks_usage/traffic_management/ingress.md
@@ -363,7 +363,7 @@ For HTTPS ingress, additional annotations are required.
 
 ## Other Ingress configurations
 
-Demos for using OSM with other Ingress resources, such as Azure Application Gateway and Gloo Edge, can be found in the [demos folder](/docs/tasks_usage/traffic_management/)
+Demos for using OSM with other Ingress resources, such as Azure Application Gateway and Gloo Edge, can be found in the [demos folder](/docs/tasks_usage/traffic_management/demos)
 
 [1]: https://github.com/openservicemesh/osm/blob/release-v0.8/README.md
 [2]: https://kubernetes.github.io/ingress-nginx/


### PR DESCRIPTION
Adds documentation for using egress policies along
with a demo guide.

Also fixes a broken references in the ingress doc.

Part of openservicemesh/osm#3045

Signed-off-by: Shashank Ram <shashr2204@gmail.com>