### PR TITLE
docs(chore): change the logo url

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -77,6 +77,7 @@ latexDashes = true
 copyright = "The Docsy Authors"
 offlineSearch = true
 prism_syntax_highlighting = true
+project_home = "https://openservicemesh.io/"
 
 [params.ui]
 navbar_logo = true

--- a/themes/dosmy/layouts/partials/navbar.html
+++ b/themes/dosmy/layouts/partials/navbar.html
@@ -1,6 +1,6 @@
 {{ $cover := .HasShortcode "blocks/cover" }}
 <nav class="js-navbar-scroll navbar navbar-expand {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar">
-        <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
+        <a class="navbar-brand" href="{{ .Site.Params.project_home }}">
 		<span class="navbar-logo">{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}{{ end }}</span><span class="text-uppercase font-weight-bold">{{ .Site.Title }}</span>
 	</a>
 	<div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">


### PR DESCRIPTION
This PR changes the url for the logo in the top left, pointing it at the OSM homepage instead of the Docs homepage.
Closes #6. 

Signed-off-by: flynnduism <dev@ronan.design>