### PR TITLE
add version menu with link to 0.8.0

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -81,6 +81,13 @@ algolia_docsearch = false
 prism_syntax_highlighting = true
 project_home = "https://openservicemesh.io/"
 
+[[params.versions]]
+  version = "latest"
+  url = "https://docs.openservicemesh.io/"
+[[params.versions]]
+  version = "0.8.0"
+  url = "https://release-v0-8.docs.openservicemesh.io/"
+
 [params.ui]
 navbar_logo = true
 sidebar_menu_compact = false


### PR DESCRIPTION
As per #36, this PR introduces the version dropdown menu in order to include a link to the [v0.8 docs](https://release-v0-8.docs.openservicemesh.io/).

<img width="242" alt="Screen Shot 2021-05-15 at 11 21 53 AM" src="https://user-images.githubusercontent.com/686194/118374230-c66d9600-b56f-11eb-95f9-1e5eeaffeec7.png">

Signed-off-by: flynnduism <dev@ronan.design>