### PR TITLE
Fixing minor errors

### DIFF
--- a/content/docs/install/manual_demo.md
+++ b/content/docs/install/manual_demo.md
@@ -2,7 +2,6 @@
 title: "OSM Manual Demo Guide"
 description: "The manual demo is a step-by-step walkthrough set of instruction of the automated demo."
 type: docs
-aliases: ["OSM Manaual Demo"]
 weight: 2
 ---
 
@@ -12,7 +11,7 @@ The OSM Manual Install Demo Guide is a step by step set of instructions to quick
 
 ## Prerequisites
 This demo of OSM v0.8.3 requires:
-  - a cluster running Kubernetes v1.17 or greater
+  - a cluster running Kubernetes v1.18 or greater
   - a workstation capable of executing [Bash](https://en.wikipedia.org/wiki/Bash_(Unix_shell)) scripts
   - [The Kubernetes command-line tool](https://kubernetes.io/docs/tasks/tools/#kubectl) - `kubectl`
 

--- a/content/docs/install/uninstallation_guide.md
+++ b/content/docs/install/uninstallation_guide.md
@@ -55,7 +55,7 @@ Alternatively, if sidecar injection is enabled via annotations on pods instead o
 Restart all pods running with a sidecar:
 
 ```console
-# If pods are running as part of a Kuberenetes deployment
+# If pods are running as part of a Kubernetes deployment
 # Can use this strategy for daemonset as well
 $ kubectl rollout restart deployment <deployment-name> -n <namespace>
 


### PR DESCRIPTION
Fixing a few small errors:
- That `aliases` directive has a typo and in any case is not needed. (Deferring the larger aliases cleanup, but might as well remove this one now.)
- Corrected minimum required k8s version
- Fixing one other minor typo

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>