### PR TITLE
manual_demo: fix HTTP route policy

### DIFF
--- a/content/docs/install/manual_demo.md
+++ b/content/docs/install/manual_demo.md
@@ -526,15 +526,12 @@ spec:
     methods:
     - GET
     headers:
-    - host: "bookstore.bookstore"
     - "user-agent": ".*-http-client/*.*"
     - "client-app": "bookbuyer"
   - name: buy-a-book
     pathRegex: ".*a-book.*new"
     methods:
     - GET
-    headers:
-    - host: "bookstore.bookstore"
 EOF
 ```
 


### PR DESCRIPTION
The existing demo is broken because of incorrect
host header matching specified which prevents
bookbuyer from accessing the bookstore service.
The host header in the HTTP request includes
the port, but the spec was missing this. Since
the host header feature is not complete (see
openservicemesh/osm#2369) and this is unnecessary
for this demo, this change removes it.

The demo works as expected with SMI policies
with this fix.

Resolves openservicemesh/osm#3491

Signed-off-by: Shashank Ram <shashr2204@gmail.com>