### PR TITLE
Update cert-manager installation instructions

### DIFF
--- a/content/docs/tasks_usage/certificates.md
+++ b/content/docs/tasks_usage/certificates.md
@@ -233,7 +233,7 @@ installation documentation for cert-manager
 [here](https://cert-manager.io/docs/installation/).
 
 Once cert-manager is installed, configure an [issuer
-resource](https://cert-manager.io/docs/installation/) to serve certificate
+resource](https://cert-manager.io/docs/configuration/) to serve certificate
 requests. It is recommended to use an `Issuer` resource kind (rather than a
 `ClusterIssuer`) which should live in the OSM namespace (`osm-system` by
 default).
@@ -244,7 +244,7 @@ as a Kubernetes secret in the OSM namespace (`osm-system` by default) at the
 `osm install --set OpenServiceMesh.caBundleSecretName=my-secret-name` (typically `osm-ca-bundle`).
 
 ```bash
-kubectl create secret -n osm-system generic osm-ca-bundle --from-file ca.tls
+kubectl create secret -n osm-system generic osm-ca-bundle --from-file ca.crt
 ```
 
 #### Configure OSM with cert-manager


### PR DESCRIPTION
Thanks for the nice installation instructions!

This PR contains two very minor changes to installation instructions for `osm` with `cert-manager`, one to create a `Secret` with the correct key name and other to point at the right place in docs for `Issuer` configuration.

Signed-off-by: irbekrm <irbekrm@gmail.com>