### PR TITLE
traffic/iptables: inbound port exclusions

### DIFF
--- a/content/docs/tasks/traffic_management/iptables_redirection.md
+++ b/content/docs/tasks/traffic_management/iptables_redirection.md
@@ -69,19 +69,19 @@ OSM provides a means to specify a global list of IP ranges to exclude from outbo
 
 Excluded IP ranges are stored in the `osm-mesh-config` `MeshConfig` custom resource and is read at the time of sidecar injection by `osm-injector`. These dynamically configurable IP ranges are programmed by the init container along with the static rules used to intercept and redirect traffic via the Envoy proxy sidecar. Excluded IP ranges will not be intercepted for traffic redirection to the Envoy proxy sidecar.
 
-### Outbound port exclusion
+### Outbound port exclusions
 
 Outbound TCP based traffic from applications is by default intercepted using the `iptables` rules programmed by OSM, and redirected to the Envoy proxy sidecar. In some cases, it might be desirable to not subject certain ports to be redirected and routed by the Envoy proxy sidecar based on service mesh policies. A common use case to exclude ports is to not route non-application logic based traffic via the Envoy proxy, such as control plane traffic. In such scenarios, excluding certain ports from being subject to service mesh traffic routing policies becomes necessary.
 
 #### 1. Global outbound port exclusions
 
-In this set up the port exclusions would be applicable to all pods/services on the mesh.
+In this set up the port exclusions would be applicable to all pods in the mesh.
 
-OSM provides a means to specify a global list of ports to exclude from outbound traffic interception in the following ways:
+OSM provides the means to specify a global list of ports to exclude from outbound traffic interception by the sidecar in the following ways:
 
 1. During OSM install using the `--set` option:
     ```bash
-    # To exclude the ports 6379 and 7070 from outbound interception
+    # To exclude the ports 6379 and 7070 from outbound sidecar interception
     osm install --set="OpenServiceMesh.outboundPortExclusionList={6379,7070}
     ```
 
@@ -91,19 +91,45 @@ OSM provides a means to specify a global list of ports to exclude from outbound 
     kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"outboundPortExclusionList":[6379, 7070]}}}'  --type=merge
     ```
 
-#### 2. Pod level outbound port exclusions
+#### 2. Pod scoped outbound port exclusions
 
-In this setup the port exclusions would be applicable to a specific pod.
-
-OSM provides a means to specify a list of ports to exclude from outbound traffic interception at pod level in the following way:
-
-1. By annotating the pod with  `openservicemesh.io/outbound-port-exclusion-list=<list of comma separated ports>` option:
-    ```bash
-    # To exclude the ports 6379 and 7070 from outbound interception on the pod
-    kubectl annotate pod <pod> openservicemesh.io/outbound-port-exclusion-list=6379,7070
-    ```
+OSM provides the means to specify a list of ports to exclude from outbound traffic interception at a per pod scope by annotating the pod with  `openservicemesh.io/outbound-port-exclusion-list=<comma separated list of ports>` option:
+```bash
+# To exclude the ports 6379 and 7070 from outbound interception on the pod
+kubectl annotate pod <pod> openservicemesh.io/outbound-port-exclusion-list=6379,7070
+```
 
 Excluded ports are stored in the `osm-mesh-config` `MeshConfig` custom resource and as an annotation on the pod. Both of these are read and merged at the time of sidecar injection by `osm-injector`. These dynamically configurable ports are programmed by the init container along with the static rules used to intercept and redirect traffic via the Envoy proxy sidecar. Excluded ports will not be intercepted for traffic redirection to the Envoy proxy sidecar.
+
+### Inbound port exclusions
+
+Similar to outbound port exclusions described above, inbound traffic on pods can be excluded from being proxied to the sidecar based on the ports the traffic is directed to.
+
+#### 1. Global inbound port exclusions
+
+In this set up the port exclusions would be applicable to all pods in the mesh.
+
+OSM provides the means to specify a global list of ports to exclude from inbound traffic interception by the sidecar in the following ways:
+
+1. During OSM install using the `--set` option:
+    ```bash
+    # To exclude the ports 6379 and 7070 from inbound sidecar interception
+    osm install --set="OpenServiceMesh.inboundPortExclusionList={6379,7070}
+    ```
+
+1. By setting the `inboundPortExclusionList` key in the `osm-mesh-config` resource:
+    ```bash
+    ## Assumes OSM is installed in the osm-system namespace
+    kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"inboundPortExclusionList":[6379, 7070]}}}'  --type=merge
+    ```
+
+#### 2. Pod scoped inbound port exclusions
+
+OSM provides the means to specify a list of ports to exclude from inbound traffic interception at a per pod scope by annotating the pod with  `openservicemesh.io/inbound-port-exclusion-list=<comma separated list of ports>` option:
+```bash
+# To exclude the ports 6379 and 7070 from inbound sidecar interception on the pod
+kubectl annotate pod <pod> openservicemesh.io/inbound-port-exclusion-list=6379,7070
+```
 
 ## Sample demo
 


### PR DESCRIPTION
Documents inbound port exclusions for sidecar traffic
interception.

Required for openservicemesh/osm#3582