### PR TITLE
fix code block formatting

### DIFF
--- a/content/docs/tasks/observability/metrics.md
+++ b/content/docs/tasks/observability/metrics.md
@@ -161,7 +161,7 @@ Enabling metrics scraping on a namespace also causes the osm-injector to add the
     prometheus.io/scrape: true
     prometheus.io/port: 15010
     prometheus.io/path: /stats/prometheus
-    ```
+   ```
 
 
 ### Available Metrics


### PR DESCRIPTION
Because the backticks were not aligned, everything after this point in
the doc was formatted as raw markdown in a code block.