### PR TITLE
[backport] ingress: fix label value

### DIFF
--- a/content/docs/tasks/traffic_management/ingress.md
+++ b/content/docs/tasks/traffic_management/ingress.md
@@ -94,7 +94,7 @@ metadata:
   name: httpbin-ingress
   namespace: httpbin
   labels:
-    openservicemesh.io/ignore: true
+    openservicemesh.io/ignore: "true"
 ```
 > Note: The value applied to this label does not matter.
 


### PR DESCRIPTION
The label value is a string, quote it so it doesn't
get interpreted as a boolean, which fails k8s API
validation.
