### PR TITLE
docs: fix broken links and use absolute paths

### DIFF
--- a/content/docs/concepts_features/osm_mesh_config.md
+++ b/content/docs/concepts_features/osm_mesh_config.md
@@ -24,7 +24,7 @@ Changes to `osm-mesh-config` can be made using the `kubectl patch` command.
 # Replace osm-system with osm-controller's namespace if using a non-default namespace
 kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enableEgress":true}}}'  --type=merge
 ```
-Refer to the [Config API reference](/docs/apidocs/config/v1alpha1.md) for more information.
+Refer to the [Config API reference](/docs/apidocs/config/v1alpha1) for more information.
 
 If an incorrect value is used, validations on the [MeshConfig CRD](https://github.com/openservicemesh/osm/blob/release-v0.9/charts/osm/crds/meshconfig.yaml) will prevent the change with an error message explaining why the value is invalid.
 For example, the below command shows what happens if we patch `enableEgress` to a non-boolean value.

--- a/content/docs/install/_index.md
+++ b/content/docs/install/_index.md
@@ -124,4 +124,4 @@ $ helm get manifest osm --namespace osm-system
 
 ## Next Steps
 
-Now that the OSM control plane is up and running, [add services](../tasks/onboard_services.md) to the mesh.
+Now that the OSM control plane is up and running, [add services](/docs/tasks/onboard_services) to the mesh.

--- a/content/docs/tasks/observability/_index.md
+++ b/content/docs/tasks/observability/_index.md
@@ -9,6 +9,6 @@ type: docs
 OSM's observability stack includes Prometheus for metrics collection, Grafana for metrics visualization, Jaeger for tracing and Fluent Bit for log forwarding to a user-defined endpoint. These are disabled by default but may be enabled during OSM installation with flags `--deploy-prometheus`, `--deploy-grafana`, `--deploy-jaeger` and `--enable-fluentbit`.
 
 ## Table of Contents
-- [Metrics - Prometheus and Grafana](./metrics.md)
-- [Tracing - Jaeger](./tracing.md)
-- [Log forwarding - Fluent Bit](./logs.md)
+- [Metrics - Prometheus and Grafana](/docs/tasks/observability/metrics)
+- [Tracing - Jaeger](/docs/tasks/observability/tracing)
+- [Log forwarding - Fluent Bit](/docs/tasks/observability/logs)

--- a/content/docs/tasks/onboard_services.md
+++ b/content/docs/tasks/onboard_services.md
@@ -8,7 +8,7 @@ weight: 1
 # Onboard Services
 The following guide describes how to onboard a Kubernetes microservice to an OSM instance.
 
-1. Refer to the [application requirements](../../application_requirements.md) guide before onboarding applications.
+1. Refer to the [application requirements](/docs/concepts_features/app_prereqs) guide before onboarding applications.
 
 1. Configure and Install [Service Mesh Interface (SMI) policies](https://github.com/servicemeshinterface/smi-spec)
 
@@ -36,8 +36,7 @@ The following guide describes how to onboard a Kubernetes microservice to an OSM
     ```
 
     To disable automatic sidecar injection as a part of enrolling a namespace into the mesh, use `osm namespace add <namespace> --disable-sidecar-injection`.
-    <!-- Please do not replace the link of `sidecar_injection.md` this format in order to work on osm website first -->
-    Once a namespace has been on-boarded, pods can be enrolled in the mesh by configuring automatic sidecar injection. See the [Sidecar Injection](../sidecar_injection) document for more details.
+    Once a namespace has been on-boarded, pods can be enrolled in the mesh by configuring automatic sidecar injection. See the [Sidecar Injection](/docs/tasks/sidecar_injection) document for more details.
 
     For an example on how to onboard and join namespaces to the OSM mesh, please see the following example:
     - [demo/join-namespaces.sh](https://github.com/openservicemesh/osm/blob/release-v0.9/demo/join-namespaces.sh)

--- a/content/docs/tasks/traffic_management/_index.md
+++ b/content/docs/tasks/traffic_management/_index.md
@@ -5,7 +5,7 @@ type: docs
 ---
 
 ## Table of Contents
-- [Egress](./egress.md)
-- [Ingress](./ingress.md)
-- [Iptables Redirection](./iptables_redirection.md)
-- [Permissive Traffic Policy Mode](./permissive_traffic_policy_mode.md)
+- [Egress](/docs/tasks/traffic_management/egress)
+- [Ingress](/docs/tasks/traffic_management/ingress)
+- [Iptables Redirection](/docs/tasks/traffic_management/iptables_redirection)
+- [Permissive Traffic Policy Mode](/docs/tasks/traffic_management/permissive_traffic_policy_mode)

--- a/content/docs/tasks/traffic_management/egress.md
+++ b/content/docs/tasks/traffic_management/egress.md
@@ -38,7 +38,7 @@ Egress can be enabled mesh-wide during OSM install or post install. When egress 
 
 	`osm-controller` retrieves the egress configuration from the `osm-mesh-config` `MeshConfig` custom resource in its namespace (`osm-system` by default). Use `kubectl patch` to set `enableEgress` to `true` in the `osm-mesh-config` resource.
     ```bash
-    kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enableEgress":true}}}'c--type=merge
+    kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enableEgress":true}}}' --type=merge
     ```
 
 ### Disabling mesh-wide Egress to external destinations

--- a/content/docs/tasks/traffic_management/troubleshooting/_index.md
+++ b/content/docs/tasks/traffic_management/troubleshooting/_index.md
@@ -5,6 +5,6 @@ type: docs
 ---
 
 ## Table of Contents
-- [Iptables redirection troubleshooting](./iptables_redirection.md)
-- [Egress troubleshooting](./egress.md)
-- [Permissive traffic policy mode troubleshooting](./permissive_traffic_policy_mode.md)
+- [Iptables redirection troubleshooting](/docs/tasks/traffic_management/troubleshooting/iptables_redirection)
+- [Egress troubleshooting](/docs/tasks/traffic_management/troubleshooting/egress)
+- [Permissive traffic policy mode troubleshooting](/docs/tasks/traffic_management/troubleshooting/permissive_traffic_policy_mode)


### PR DESCRIPTION
- Fixes broken links and uses absolute paths to
  avoid the broken links that arise from using
  relative paths incorrectly
- Fixes typo in command
- Removes unnecessary aliases

Testing done:
- Verified the changes work as expected on the website preview
