### PR TITLE
demos/egress_policy: make title and topic name consistent

### DIFF
--- a/content/docs/demos/egress_policy.md
+++ b/content/docs/demos/egress_policy.md
@@ -1,6 +1,6 @@
 ---
-title: "Egress Policy Demo"
-description: "Accesing external services using Egress policies."
+title: "Egress Policy"
+description: "Accesing external services using Egress policies"
 type: docs
 ---
 


### PR DESCRIPTION
Drops the `demo` and period from the title to make it consistent
with other demo docs within the same section.