### PR TITLE
traffic_management: reorganize demos

### DIFF
--- a/content/docs/demos/egress_passthrough.md
+++ b/content/docs/demos/egress_passthrough.md
@@ -1,0 +1,69 @@
+---
+title: "Egress Passthrough to Unknown Destinations"
+description: "Accessing external services without Egress policies"
+type: docs
+weight: 5
+---
+
+This guide demonstrates a client within the service mesh accessing destinations external to the mesh using OSM's Egress capability to passthrough traffic to unknown destinations without an Egress policy.
+
+
+## Prerequisites
+
+- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Have OSM installed.
+- Have `kubectl` available to interact with the API server.
+- Have `osm` CLI available for managing the service mesh.
+
+
+## HTTP(S) mesh-wide Egress passthrough demo
+
+1. Enable global egress passthrough if not enabled:
+    ```bash
+    export osm_namespace=<osm-namespace> # Replace <osm-namespace> with the namespace where OSM is installed
+    kubectl patch meshconfig osm-mesh-config -n "$osm_namespace" -p '{"spec":{"traffic":{"enableEgress":true}}}'  --type=merge
+    ```
+
+1. Deploy the `curl` client into the `curl` namespace after enrolling its namespace to the mesh.
+    ```bash
+    # Create the curl namespace
+    kubectl create namespace curl
+
+    # Add the namespace to the mesh
+    osm namespace add curl
+
+    # Deploy curl client in the curl namespace
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/main/docs/example/manifests/samples/curl/curl.yaml -n curl
+    ```
+
+    Confirm the `curl` client pod is up and running.
+
+    ```console
+    $ kubectl get pods -n curl
+    NAME                    READY   STATUS    RESTARTS   AGE
+    curl-54ccc6954c-9rlvp   2/2     Running   0          20s
+    ```
+
+1. Confirm the `curl` client is able to make successful HTTPS requests to the `httpbin.org` website on port `443`.
+    ```console
+    $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I https://httpbin.org:443
+    HTTP/2 200
+    date: Tue, 16 Mar 2021 22:19:00 GMT
+    content-type: text/html; charset=utf-8
+    content-length: 9593
+    server: gunicorn/19.9.0
+    access-control-allow-origin: *
+    access-control-allow-credentials: true
+    ```
+
+    A `200 OK` response indicates the HTTPS request from the `curl` client to the `httpbin.org` website was successful.
+
+1. Confirm the HTTPS requests fail when mesh-wide egress is disabled.
+    ```bash
+    kubectl patch meshconfig osm-mesh-config -n "$osm_namespace" -p '{"spec":{"traffic":{"enableEgress":false}}}'  --type=merge
+    ```
+    ```console
+    $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I https://httpbin.org:443
+	  curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to httpbin.org:443
+	  command terminated with exit code 35
+    ```

--- a/content/docs/demos/egress_policy.md
+++ b/content/docs/demos/egress_policy.md
@@ -1,15 +1,27 @@
 ---
 title: "Egress Policy"
-description: "Accesing external services using Egress policies"
+description: "Accessing external services using Egress policies"
 type: docs
+weight: 4
 ---
 
-This guide demoes a client within the service mesh accessing destinations external to the mesh using OSM's Egress policy API.
+This guide demonstrates a client within the service mesh accessing destinations external to the mesh using OSM's Egress policy API.
+
 
 ## Prerequisites
-1. Install OSM with the Egress policy feature enabled:
+
+- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Have OSM installed.
+- Have `kubectl` available to interact with the API server.
+- Have `osm` CLI available for managing the service mesh.
+
+
+## Demo
+
+1. Enable egress policy if not enabled:
     ```bash
-    osm install --set=OpenServiceMesh.featureFlags.enableEgressPolicy=true
+    export osm_namespace=<osm-namespace> # Replace <osm-namespace> with the namespace where OSM is installed
+    kubectl patch meshconfig osm-mesh-config -n "$osm_namespace" -p '{"spec":{"featureFlags":{"enableEgressPolicy":true}}}'  --type=merge
     ```
 
 1. Deploy the `curl` client into the `curl` namespace after enrolling its namespace to the mesh.
@@ -21,7 +33,7 @@ This guide demoes a client within the service mesh accessing destinations extern
     osm namespace add curl
 
     # Deploy curl client in the curl namespace
-    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/release-v0.9/docs/example/manifests/samples/curl/curl.yaml -n curl
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/main/docs/example/manifests/samples/curl/curl.yaml -n curl
     ```
 
     Confirm the `curl` client pod is up and running.

--- a/content/docs/demos/ingress_contour_demo.md
+++ b/content/docs/demos/ingress_contour_demo.md
@@ -2,6 +2,7 @@
 title: "Ingress with Contour"
 description: "HTTP and HTTPS ingress with Contour ingress controller"
 type: docs
+weight: 3
 ---
 
 OSM provides the option to use [Contour](https://projectcontour.io) ingress controller and Envoy based edge proxy to route external traffic to service mesh backends. This guide will demonstrate how to configure HTTP and HTTPS ingress to a service part of an OSM managed service mesh.

--- a/content/docs/demos/outbound_ip_exclusion.md
+++ b/content/docs/demos/outbound_ip_exclusion.md
@@ -1,0 +1,117 @@
+---
+title: "Outbound Traffic IP Range Exclusions"
+description: "Excluding IP address ranges of outbound traffic from sidecar interception"
+type: docs
+weight: 2
+---
+
+This guide demonstrates how outbound IP address ranges can be excluded from being intercepted by OSM's proxy sidecar, so as to not subject them to service mesh filtering and routing policies.
+
+## Prerequisites
+
+- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Have OSM installed.
+- Have `kubectl` available to interact with the API server.
+- Have `osm` CLI available for managing the service mesh.
+
+
+## Demo
+
+The following demo shows an HTTP `curl` client making HTTP requests to the `httpbin.org` website directly using its IP address. We will explicitly disable the egress functionality to ensure traffic to a non-mesh destination (`httpbin.org` in this demo) is not able to egress the pod.
+
+1. Disable mesh-wide egress passthrough.
+    ```bash
+    export osm_namespace=<osm-namespace> # Replace <osm-namespace> with the namespace where OSM is installed
+    kubectl patch meshconfig osm-mesh-config -n "$osm_namespace" -p '{"spec":{"traffic":{"enableEgress":false}}}'  --type=merge
+    ```
+
+1. Deploy the `curl` client into the `curl` namespace after enrolling its namespace to the mesh.
+
+    ```bash
+    # Create the curl namespace
+    kubectl create namespace curl
+
+    # Add the namespace to the mesh
+    osm namespace add curl
+
+    # Deploy curl client in the curl namespace
+    kubectl apply -f docs/example/manifests/samples/curl/curl.yaml -n curl
+    ```
+
+    Confirm the `curl` client pod is up and running.
+
+    ```console
+    $ kubectl get pods -n curl
+    NAME                    READY   STATUS    RESTARTS   AGE
+    curl-54ccc6954c-9rlvp   2/2     Running   0          20s
+    ```
+
+1. Retrieve the public IP address for the `httpbin.org` website. For the purpose of this demo, we will test with a single IP range to be excluded from traffic interception. In this example, we will use the IP address `54.91.118.50` represented by the IP range `54.91.118.50/32`, to make HTTP requests with and without outbound IP range exclusions configured.
+    ```console
+    $ nslookup httpbin.org
+    Server:		172.23.48.1
+    Address:	172.23.48.1#53
+
+    Non-authoritative answer:
+    Name:	httpbin.org
+    Address: 54.91.118.50
+    Name:	httpbin.org
+    Address: 54.166.163.67
+    Name:	httpbin.org
+    Address: 34.231.30.52
+    Name:	httpbin.org
+    Address: 34.199.75.4
+    ```
+
+    > Note: Replace `54.91.118.50` with a valid IP address returned by the above command in subsequent steps.
+
+1. Confirm the `curl` client is unable to make successful HTTP requests to the `httpbin.org` website running on `http://54.91.118.50:80`.
+
+    ```console
+    $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I http://54.91.118.50:80
+    curl: (7) Failed to connect to 54.91.118.50 port 80: Connection refused
+    command terminated with exit code 7
+    ```
+
+    The failure above is expected because by default outbound traffic is redirected via the Envoy proxy sidecar running on the `curl` client's pod, and the proxy subjects this traffic to service mesh policies which does not allow this traffic.
+
+1. Program OSM to exclude the IP range `54.91.118.50/32` IP range
+    ```bash
+    kubectl patch meshconfig osm-mesh-config -n "$osm_namespace" -p '{"spec":{"traffic":{"outboundIPRangeExclusionList":["54.91.118.50/32"]}}}'  --type=merge
+    ```
+
+1. Confirm the MeshConfig has been updated as expected
+    ```console
+    # 54.91.118.50 is one of the IP addresses of httpbin.org
+    $ kubectl get meshconfig osm-mesh-config -n "$osm_namespace" -o jsonpath='{.spec.traffic.outboundIPRangeExclusionList}{"\n"}'
+    ["54.91.118.50/32"]
+    ```
+
+1. Restart the `curl` client pod so the updated outbound IP range exclusions can be configured. It is important to note that existing pods must be restarted to pick up the updated configuration because the traffic interception rules are programmed by the init container only at the time of pod creation.
+    ```bash
+    kubectl rollout restart deployment curl -n curl
+    ```
+
+    Wait for the restarted pod to be up and running.
+
+1. Confirm the `curl` client is able to make successful HTTP requests to the `httpbin.org` website running on `http://54.91.118.50:80`
+    ```console
+    # 54.91.118.50 is one of the IP addresses for httpbin.org
+    $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I http://54.91.118.50:80
+    HTTP/1.1 200 OK
+    Date: Thu, 18 Mar 2021 23:17:44 GMT
+    Content-Type: text/html; charset=utf-8
+    Content-Length: 9593
+    Connection: keep-alive
+    Server: gunicorn/19.9.0
+    Access-Control-Allow-Origin: *
+    Access-Control-Allow-Credentials: true
+    ```
+
+1. Confirm that HTTP requests to other IP addresses of the `httpbin.org` website that are not excluded fail
+    ```console
+    # 34.199.75.4 is one of the IP addresses for httpbin.org
+    $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I http://34.199.75.4:80
+    curl: (7) Failed to connect to 34.199.75.4 port 80: Connection refused
+    command terminated with exit code 7
+    ```

--- a/content/docs/demos/permissive_traffic_mode.md
+++ b/content/docs/demos/permissive_traffic_mode.md
@@ -1,0 +1,103 @@
+---
+title: "Permissive Traffic Policy Mode"
+description: "Set up application connectivity using service discovery without explicit SMI policies"
+type: docs
+weight: 1
+---
+
+This guide demonstrates a client and server application within the service mesh communicating using OSM's permissive traffic policy mode, which configures application connectivity using service discovery without the need for explicit [SMI traffic access policies](https://github.com/servicemeshinterface/smi-spec/blob/main/apis/traffic-access/v1alpha3/traffic-access.md).
+
+
+## Prerequisites
+
+- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Have OSM installed.
+- Have `kubectl` available to interact with the API server.
+- Have `osm` CLI available for managing the service mesh.
+
+
+## Demo
+
+The following demo shows an HTTP `curl` client making HTTP requests to the `httpbin` service using permissive traffic policy mode.
+
+1. Enable permissive mode if not enabled.
+    ```bash
+    export osm_namespace=<osm-namespace> # Replace <osm-namespace> with the namespace where OSM is installed
+    kubectl patch meshconfig osm-mesh-config -n "$osm_namespace" -p '{"spec":{"traffic":{"enablePermissiveTrafficPolicyMode":true}}}'  --type=merge
+    ```
+
+1. Deploy the `httpbin` service into the `httpbin` namespace after enrolling its namespace to the mesh. The `httpbin` service runs on port `14001`.
+
+    ```bash
+    # Create the httpbin namespace
+    kubectl create namespace httpbin
+
+    # Add the namespace to the mesh
+    osm namespace add httpbin
+
+    # Deploy httpbin service in the httpbin namespace
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/main/docs/example/manifests/samples/httpbin/httpbin.yaml -n httpbin
+    ```
+
+    Confirm the `httpbin` service and pods are up and running.
+
+    ```console
+    $ kubectl get svc -n httpbin
+    NAME      TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)     AGE
+    httpbin   ClusterIP   10.96.198.23   <none>        14001/TCP   20s
+    ```
+
+    ```console
+    $ kubectl get pods -n httpbin
+    NAME                     READY   STATUS    RESTARTS   AGE
+    httpbin-5b8b94b9-lt2vs   2/2     Running   0          20s
+    ```
+
+1. Deploy the `curl` client into the `curl` namespace after enrolling its namespace to the mesh.
+
+    ```bash
+    # Create the curl namespace
+    kubectl create namespace curl
+
+    # Add the namespace to the mesh
+    osm namespace add curl
+
+    # Deploy curl client in the curl namespace
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/main/docs/example/manifests/samples/curl/curl.yaml -n curl
+    ```
+
+    Confirm the `curl` client pod is up and running.
+
+    ```console
+    $ kubectl get pods -n curl
+    NAME                    READY   STATUS    RESTARTS   AGE
+    curl-54ccc6954c-9rlvp   2/2     Running   0          20s
+    ```
+
+1. Confirm the `curl` client is able to access the `httpbin` service on port `14001`.
+
+    ```console
+    $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I http://httpbin.httpbin:14001
+    HTTP/1.1 200 OK
+    server: envoy
+    date: Mon, 15 Mar 2021 22:45:23 GMT
+    content-type: text/html; charset=utf-8
+    content-length: 9593
+    access-control-allow-origin: *
+    access-control-allow-credentials: true
+    x-envoy-upstream-service-time: 2
+    ```
+
+    A `200 OK` response indicates the HTTP request from the `curl` client to the `httpbin` service was successful.
+
+1. Confirm the HTTP requests fail when permissive traffic policy mode is disabled.
+
+    ```bash
+    kubectl patch meshconfig osm-mesh-config -n "$osm_namespace" -p '{"spec":{"traffic":{"enablePermissiveTrafficPolicyMode":false}}}'  --type=merge
+    ```
+
+    ```console
+    $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I http://httpbin.httpbin:14001
+    curl: (7) Failed to connect to httpbin.httpbin port 14001: Connection refused
+    command terminated with exit code 7
+    ```

--- a/content/docs/demos/prometheus_grafana.md
+++ b/content/docs/demos/prometheus_grafana.md
@@ -2,7 +2,7 @@
 title: "Prometheus & Grafana"
 description: "Describes basic steps to get up and running a Prometheus and Grafana stack with OSM specific configuration and Dashboards"
 type: docs
-weight: 5
+weight: 6
 ---
 
 # OSM's Prometheus and Grafana stack

--- a/content/docs/guides/traffic_management/egress.md
+++ b/content/docs/guides/traffic_management/egress.md
@@ -21,13 +21,25 @@ While in-mesh traffic is routed based on L7 traffic policies, egress traffic is 
 
 There are two mechanisms to configure Egress:
 
-1. Using a mesh-wide global setting: the setting is toggled on or off and affects all pods in the mesh, enabling which allows traffic destined to destinations outside the mesh to egress the pod.
-2. Using the Egress policy API: to provide fine grained access control over external traffic
+1. Using the Egress policy API: to provide fine grained access control over external traffic
+2. Using the mesh-wide global egress passthrough setting: the setting is toggled on or off and affects all pods in the mesh, enabling which allows traffic destined to destinations outside the mesh to egress the pod.
 
 
-## Configuring mesh-wide Egress
+## 1. Configuring Egress policies
 
-### Enabling mesh-wide Egress to external destinations
+OSM supports configuring fine grained policies for traffic destined to external endpoints using its [Egress policy API][1]. To use this feature, enable it if not enabled:
+```bash
+# Replace <osm-namespace> with the namespace where OSM is installed
+kubectl patch meshconfig osm-mesh-config -n <osm-namespace> -p '{"spec":{"featureFlags":{"enableEgressPolicy":true}}}'  --type=merge
+```
+
+Refer to the [Egress policy demo](/docs/demos/egress_policy) and [API documentation][1] on how to configure policies for routing egress traffic for various protocols.
+
+
+## 2. Configuring mesh-wide Egress passthrough
+
+### Enabling mesh-wide Egress passthrough to external destinations
+
 Egress can be enabled mesh-wide during OSM install or post install. When egress is enabled mesh-wide, outbound traffic from pods are allowed to egress the pod as long as the traffic does not match in-mesh traffic policies that otherwise deny the traffic.
 
 1. During OSM install (default `OpenServiceMesh.enableEgress=false`):
@@ -42,7 +54,8 @@ Egress can be enabled mesh-wide during OSM install or post install. When egress 
     kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enableEgress":true}}}' --type=merge
     ```
 
-### Disabling mesh-wide Egress to external destinations
+### Disabling mesh-wide Egress passthrough to external destinations
+
 Similar to enabling egress, mesh-wide egress can be disabled during OSM install or post install.
 
 1. During OSM install:
@@ -59,69 +72,16 @@ Similar to enabling egress, mesh-wide egress can be disabled during OSM install 
 With egress disabled, traffic from pods within the mesh will not be able to access external services outside the cluster.
 
 ### How it works
+
 When egress is enabled mesh-wide, OSM controller programs every Envoy proxy sidecar in the mesh with a wildcard rule that matches outbound destinations that do not correspond to in-mesh services. The wildcard rule that matches such external traffic simply proxies the traffic as is to its original destination without subjecting them to L4 or L7 traffic policies.
 
 OSM supports egress for traffic that uses TCP as the underlying transport. This includes raw TCP traffic, HTTP, HTTPS, gRPC etc.
 
 Since mesh-wide egress is a global setting and operates as a passthrough to unknown destinations, fine grained access control (such as applying TCP or HTTP routing policies) over egress traffic is not possible.
 
-### Sample demo with mesh-wide Egress
+Refer to the [Egress passthrough demo](/docs/demos/egress_passthrough) to learn more.
 
-#### HTTP(S) traffic with mesh-wide Egress
-
-The following demo shows a `curl` client making HTTPS requests to the external `httpbin.org` website using Egress.
-
-1. Install OSM with global egress enabled.
-    ```bash
-    osm install --set OpenServiceMesh.enableEgress=true
-    ```
-
-1. Deploy the `curl` client into the `curl` namespace after enrolling its namespace to the mesh.
-    ```bash
-    # Create the curl namespace
-    kubectl create namespace curl
-
-    # Add the namespace to the mesh
-    osm namespace add curl
-
-    # Deploy curl client in the curl namespace
-    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/release-v0.9/docs/example/manifests/samples/curl/curl.yaml -n curl
-    ```
-
-    Confirm the `curl` client pod is up and running.
-
-    ```console
-    $ kubectl get pods -n curl
-    NAME                    READY   STATUS    RESTARTS   AGE
-    curl-54ccc6954c-9rlvp   2/2     Running   0          20s
-    ```
-
-1. Confirm the `curl` client is able to make successful HTTPS requests to the `httpbin.org` website on port `443`.
-    ```console
-    $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I https://httpbin.org:443
-    HTTP/2 200
-    date: Tue, 16 Mar 2021 22:19:00 GMT
-    content-type: text/html; charset=utf-8
-    content-length: 9593
-    server: gunicorn/19.9.0
-    access-control-allow-origin: *
-    access-control-allow-credentials: true
-    ```
-
-    A `200 OK` response indicates the HTTPS request from the `curl` client to the `httpbin.org` website was successful.
-
-1. Confirm the HTTPS requests fail when mesh-wide egress is disabled.
-    ```bash
-    # Assumes OSM is installed in the osm-system namespace
-    kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enableEgress":false}}}'  --type=merge
-    ```
-    ```console
-    $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I https://httpbin.org:443
-	  curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to httpbin.org:443
-	  command terminated with exit code 35
-    ```
-
-### Envoy configurations
+#### Envoy configurations
 
 When egress is globally enabled in the mesh, OSM controller programs each Envoy proxy sidecar to match external or unknown destinations using a default filter chain on the outbound listener configuration. The default filter chain is named `outbound-egress-filter-chain` as seen in the below configuration snippet. Any traffic that matches the default egress filter chain on the outbound listener is proxied to its original destination via the `passthrough-outbound` cluster.
 
@@ -164,11 +124,5 @@ When egress is globally enabled in the mesh, OSM controller programs each Envoy 
 }
 ```
 
-## Configuring Egress policies
 
-OSM supports configuring fine grained policies for traffic destined to external endpoints using its Egress policy API. To use this feature, enable it during install:
-```bash
-osm install --set=OpenServiceMesh.featureFlags.enableEgressPolicy=true
-```
-
-Refer to the [Egress policy v1alpha1 API documentation](/docs/apidocs/policy/v1alpha1) to configure egress policies and [sample demos using the Egress policy API](/docs/demos/egress_policy).
+[1]: /docs/api_reference/policy/v1alpha1/#policy.openservicemesh.io/v1alpha1.EgressSpec

--- a/content/docs/guides/traffic_management/iptables_redirection.md
+++ b/content/docs/guides/traffic_management/iptables_redirection.md
@@ -67,7 +67,7 @@ OSM provides a means to specify a global list of IP ranges to exclude from outbo
     kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"outboundIPRangeExclusionList":["1.1.1.1/32", "2.2.2.2/24"]}}}'  --type=merge
     ```
 
-Excluded IP ranges are stored in the `osm-mesh-config` `MeshConfig` custom resource and is read at the time of sidecar injection by `osm-injector`. These dynamically configurable IP ranges are programmed by the init container along with the static rules used to intercept and redirect traffic via the Envoy proxy sidecar. Excluded IP ranges will not be intercepted for traffic redirection to the Envoy proxy sidecar.
+Excluded IP ranges are stored in the `osm-mesh-config` `MeshConfig` custom resource and is read at the time of sidecar injection by `osm-injector`. These dynamically configurable IP ranges are programmed by the init container along with the static rules used to intercept and redirect traffic via the Envoy proxy sidecar. Excluded IP ranges will not be intercepted for traffic redirection to the Envoy proxy sidecar. Refer to the [outbound IP range exclusion demo](/docs/demos/outbound_ip_exclusion) to learn more.
 
 ### Outbound port exclusions
 
@@ -130,107 +130,6 @@ OSM provides the means to specify a list of ports to exclude from inbound traffi
 # To exclude the ports 6379 and 7070 from inbound sidecar interception on the pod
 kubectl annotate pod <pod> openservicemesh.io/inbound-port-exclusion-list=6379,7070
 ```
-
-## Sample demo
-
-### Traffic redirection with IP range exclusions
-
-The following demo shows an HTTP `curl` client making HTTP requests to the `httpbin.org` website directly using its IP address. We will explicitly disable the egress functionality to ensure traffic to a non-mesh destination (`httpbin.org` in this demo) is not able to egress the pod.
-
-1. Install OSM with egress disabled.
-    ```bash
-    osm install --set OpenServiceMesh.enableEgress=false
-    ```
-
-1. Deploy the `curl` client into the `curl` namespace after enrolling its namespace to the mesh.
-
-    ```bash
-    # Create the curl namespace
-    kubectl create namespace curl
-
-    # Add the namespace to the mesh
-    osm namespace add curl
-
-    # Deploy curl client in the curl namespace
-    kubectl apply -f docs/example/manifests/samples/curl/curl.yaml -n curl
-    ```
-
-    Confirm the `curl` client pod is up and running.
-
-    ```console
-    $ kubectl get pods -n curl
-    NAME                    READY   STATUS    RESTARTS   AGE
-    curl-54ccc6954c-9rlvp   2/2     Running   0          20s
-    ```
-
-1. Retrieve the public IP address for the `httpbin.org` website. For the purpose of this demo, we will test with a single IP range to be excluded from traffic interception. In this example, we will use the IP address `54.91.118.50` represented by the IP range `54.91.118.50/32`, to make HTTP requests with and without outbound IP range exclusions configured.
-    ```console
-    $ nslookup httpbin.org
-    Server:		172.23.48.1
-    Address:	172.23.48.1#53
-
-    Non-authoritative answer:
-    Name:	httpbin.org
-    Address: 54.91.118.50
-    Name:	httpbin.org
-    Address: 54.166.163.67
-    Name:	httpbin.org
-    Address: 34.231.30.52
-    Name:	httpbin.org
-    Address: 34.199.75.4
-    ```
-
-1. Confirm the `curl` client is unable to make successful HTTP requests to the `httpbin.org` website running on `http://54.91.118.50:80`.
-
-    ```console
-    $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I http://54.91.118.50:80
-    curl: (7) Failed to connect to 54.91.118.50 port 80: Connection refused
-    command terminated with exit code 7
-    ```
-
-    The failure above is expected because by default outbound traffic is redirected via the Envoy proxy sidecar running on the `curl` client's pod, and the proxy subjects this traffic to service mesh policies which does not allow this traffic.
-
-1. Program OSM to exclude the IP range `54.91.118.50/32` IP range
-    ```bash
-    ## Assumes OSM is installed in the osm-system namespace
-    kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"outboundIPRangeExclusionList":["54.91.118.50/32"]}}}'  --type=merge
-    ```
-
-1. Confirm the MeshConfig has been updated as expected
-    ```console
-    # 54.91.118.50 is one of the IP addresses for httpbin.org
-    $ kubectl get meshconfig osm-mesh-config -n osm-system -o jsonpath='{.spec.traffic.outboundIPRangeExclusionList}{"\n"}'
-    ["54.91.118.50/32"]
-    ```
-
-1. Restart the `curl` client pod so the updated outbound IP range exclusions can be configured. It is important to note that existing pods must be restarted to pick up the updated configuration because the traffic interception rules are programmed by the init container only at the time of pod creation.
-    ```bash
-    kubectl rollout restart deployment curl -n curl
-    ```
-
-    Wait for the restarted pod to be up and running.
-
-1. Confirm the `curl` client is able to make successful HTTP requests to the `httpbin.org` website running on `http://54.91.118.50:80`
-    ```console
-    # 54.91.118.50 is one of the IP addresses for httpbin.org
-    $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I http://54.91.118.50:80
-    HTTP/1.1 200 OK
-    Date: Thu, 18 Mar 2021 23:17:44 GMT
-    Content-Type: text/html; charset=utf-8
-    Content-Length: 9593
-    Connection: keep-alive
-    Server: gunicorn/19.9.0
-    Access-Control-Allow-Origin: *
-    Access-Control-Allow-Credentials: true
-    ```
-
-1. Confirm that HTTP requests to other IP addresses of the `httpbin.org` website that are not excluded fail
-    ```console
-    # 34.199.75.4 is one of the IP addresses for httpbin.org
-    $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I http://34.199.75.4:80
-    curl: (7) Failed to connect to 34.199.75.4 port 80: Connection refused
-    command terminated with exit code 7
-    ```
 
 ## Iptables configuration
 

--- a/content/docs/guides/traffic_management/permissive_mode.md
+++ b/content/docs/guides/traffic_management/permissive_mode.md
@@ -52,95 +52,9 @@ kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"
 ## How it works
 When permissive traffic policy mode is enabled, OSM controller discovers all services that are a part of the mesh and programs wildcard traffic routing rules on each Envoy proxy sidecar to reach every other service in the mesh. Additionally, each proxy fronting workloads that are associated with a service is configured to accept all traffic destined to the service. Depending on the application protocol of the service (HTTP, TCP, gRPC etc.), appropriate traffic routing rules are configured on the Envoy sidecar to allow all traffic for that particular type.
 
-## Sample demo
+Refer to the [Permissive traffic policy mode demo](/docs/demos/permissive_traffic_mode) to learn more.
 
-### HTTP traffic in permissive mode
-
-The following demo shows an HTTP `curl` client making HTTP requests to the `httpbin` service using permissive traffic policy mode.
-
-1. Install OSM with permissive traffic policy mode enabled.
-    ```bash
-    osm install --set OpenServiceMesh.enablePermissiveTrafficPolicy=true
-    ```
-
-1. Deploy the `httpbin` service into the `httpbin` namespace after enrolling its namespace to the mesh. The `httpbin` service runs on port `14001`.
-
-    ```bash
-    # Create the httpbin namespace
-    kubectl create namespace httpbin
-
-    # Add the namespace to the mesh
-    osm namespace add httpbin
-
-    # Deploy httpbin service in the httpbin namespace
-    kubectl apply -f docs/example/manifests/samples/httpbin/httpbin.yaml -n httpbin
-    ```
-
-    Confirm the `httpbin` service and pods are up and running.
-
-    ```console
-    $ kubectl get svc -n httpbin
-    NAME      TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)     AGE
-    httpbin   ClusterIP   10.96.198.23   <none>        14001/TCP   20s
-    ```
-
-    ```console
-    $ kubectl get pods -n httpbin
-    NAME                     READY   STATUS    RESTARTS   AGE
-    httpbin-5b8b94b9-lt2vs   2/2     Running   0          20s
-    ```
-
-1. Deploy the `curl` client into the `curl` namespace after enrolling its namespace to the mesh.
-
-    ```bash
-    # Create the curl namespace
-    kubectl create namespace curl
-
-    # Add the namespace to the mesh
-    osm namespace add curl
-
-    # Deploy curl client in the curl namespace
-    kubectl apply -f docs/example/manifests/samples/curl/curl.yaml -n curl
-    ```
-
-    Confirm the `curl` client pod is up and running.
-
-    ```console
-    $ kubectl get pods -n curl
-    NAME                    READY   STATUS    RESTARTS   AGE
-    curl-54ccc6954c-9rlvp   2/2     Running   0          20s
-    ```
-
-1. Confirm the `curl` client is able to access the `httpbin` service on port `14001`.
-
-    ```console
-    $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I http://httpbin.httpbin:14001
-    HTTP/1.1 200 OK
-    server: envoy
-    date: Mon, 15 Mar 2021 22:45:23 GMT
-    content-type: text/html; charset=utf-8
-    content-length: 9593
-    access-control-allow-origin: *
-    access-control-allow-credentials: true
-    x-envoy-upstream-service-time: 2
-    ```
-
-    A `200 OK` response indicates the HTTP request from the `curl` client to the `httpbin` service was successful.
-
-1. Confirm the HTTP requests fail when permissive traffic policy mode is disabled.
-
-    ```bash
-    # Assumes OSM is installed in the osm-system namespace
-    kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enablePermissiveTrafficPolicyMode":false}}}'  --type=merge
-    ```
-
-    ```console
-    $ kubectl exec -n curl -ti "$(kubectl get pod -n curl -l app=curl -o jsonpath='{.items[0].metadata.name}')" -c curl -- curl -I http://httpbin.httpbin:14001
-    curl: (7) Failed to connect to httpbin.httpbin port 14001: Connection refused
-    command terminated with exit code 7
-    ```
-
-## Envoy configurations
+### Envoy configurations
 In permissive mode, OSM controller programs wildcard routes for client applications to communicate with services. Following are the envoy inbound and outbound filter and route configuration snippets from the `curl` and `httpbin` sidecar proxies.
 
 1. Outbound Envoy configuration on the `curl` client pod:


### PR DESCRIPTION
- Consolidates the traffic management demos under `docs/demos`
- Removes the install step from demos to make it a prerequisite
- Removes hardcoded install namespace

Signed-off-by: Shashank Ram <shashr2204@gmail.com>