### PR TITLE
demos/ingress: fix typo

### DIFF
--- a/content/docs/demos/ingress_contour_demo.md
+++ b/content/docs/demos/ingress_contour_demo.md
@@ -122,7 +122,7 @@ x-envoy-upstream-service-time: 3
 vary: Accept-Encoding
 ```
 
-### HTTP Ingress (mTLS and TLS)
+### HTTPS Ingress (mTLS and TLS)
 
 To proxy connections to TLS backends using HTTPS, the backend service must be annotated with the port as follows:
 ```bash


### PR DESCRIPTION
Fixes a typo in the HTTPS ingress section.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>