### PR TITLE
doc(psp): Deprecate PSP support

### DIFF
--- a/content/docs/getting_started/install.md
+++ b/content/docs/getting_started/install.md
@@ -73,6 +73,10 @@ To install OSM on OpenShift:
 
 ### Pod Security Policy
 
+**Deprecated: PSP support has been deprecated in OSM since v0.10.0**
+
+**PSP support will be removed in OSM 1.0.0**
+
 If you are running OSM in a cluster with PSPs enabled, pass in `--set OpenServiceMesh.pspEnabled=true` to your `osm install` or `helm install` CLI command.
 
 ## Inspect OSM Components


### PR DESCRIPTION
PSP support is being deprecated in OSM as it is being deprecated in Kubernetes. We will explore replacing it with [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) in the future
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>