### PR TITLE
state CLI and chart version compatibility

### DIFF
--- a/content/docs/getting_started/install.md
+++ b/content/docs/getting_started/install.md
@@ -14,6 +14,12 @@ weight: 2
 
 Use the `osm` CLI to install the OSM control plane on to a Kubernetes cluster.
 
+#### OSM CLI and Chart Compatibility
+
+Each version of the OSM CLI is designed to work only with the matching version of the OSM Helm chart. Many operations may still work when some version skew exists, but those scenarios are not tested and issues that arise when using different CLI and chart versions may not get fixed even if reported.
+
+#### Running the CLI
+
 Run `osm install`.
 
 ```console

--- a/content/docs/getting_started/upgrade.md
+++ b/content/docs/getting_started/upgrade.md
@@ -62,7 +62,7 @@ Please check the `CRD Updates` section of the [release notes](https://github.com
 - Kubernetes cluster with the OSM control plane installed
     - Ensure that the Kubernetes cluster has the minimum Kubernetes version required by the new OSM chart. This can be found in the [Installation Pre-requisites](/docs/getting_started/install#Pre-requisites)
 - `osm` CLI installed
-  - By default, the `osm` CLI will upgrade to the same chart version that it installs. e.g. v0.9.2 of the `osm` CLI will upgrade to v0.9.2 of the OSM Helm chart.
+  - By default, the `osm` CLI will upgrade to the same chart version that it installs. e.g. v0.9.2 of the `osm` CLI will upgrade to v0.9.2 of the OSM Helm chart. Upgrading to any other version of the Helm chart than the version matching the CLI may work, but those scenarios are not tested and issues that arise may not get fixed even if reported.
 
 The `osm mesh upgrade` command performs a `helm upgrade` of the existing Helm release for a mesh.
 


### PR DESCRIPTION
This change clarifies that each version of the OSM CLI is only supported
when operating on the OSM chart with the same version.

Fixes #94