### PR TITLE
Correct --set documentation for osm install

### DIFF
--- a/content/docs/getting_started/quickstart/manual_demo.md
+++ b/content/docs/getting_started/quickstart/manual_demo.md
@@ -67,10 +67,10 @@ will be injected with Envoy, but traffic will flow through the proxy and will no
 
 ```bash
 osm install \
-    --set=OpenServiceMesh.enablePermissiveTrafficPolicy=true \
-    --set=OpenServiceMesh.deployPrometheus=true \
-    --set=OpenServiceMesh.deployGrafana=true \
-    --set=OpenServiceMesh.deployJaeger=true
+    --set OpenServiceMesh.enablePermissiveTrafficPolicy=true \
+    --set OpenServiceMesh.deployPrometheus=true \
+    --set OpenServiceMesh.deployGrafana=true \
+    --set OpenServiceMesh.deployJaeger=true
 ```
 
 This installed OSM Controller in the `osm-system` namespace.
@@ -236,7 +236,7 @@ In permissive traffic policy mode, application connectivity within the mesh is a
 
 1. During install using `osm` CLI:
   ```bash
-  osm install --set=OpenServiceMesh.enablePermissiveTrafficPolicy=true
+  osm install --set OpenServiceMesh.enablePermissiveTrafficPolicy=true
   ```
 
 1. Post install by patching the `osm-mesh-config` custom resource in the control plane's namespace (`osm-system` by default)

--- a/content/docs/guides/app_onboarding/_index.md
+++ b/content/docs/guides/app_onboarding/_index.md
@@ -12,7 +12,7 @@ The following guide describes how to onboard a Kubernetes microservice to an OSM
 
 1. Configure and Install [Service Mesh Interface (SMI) policies](https://github.com/servicemeshinterface/smi-spec)
 
-    OSM conforms to the SMI specification. By default, OSM denies all traffic communications between Kubernetes services unless explicitly allowed by SMI policies. This behavior can be overridden with the `--set=OpenServiceMesh.enablePermissiveTrafficPolicy=true` flag on the `osm install` command, allowing SMI policies not to be enforced while allowing traffic and services to still take advantage of features such as mTLS-encrypted traffic, metrics, and tracing.
+    OSM conforms to the SMI specification. By default, OSM denies all traffic communications between Kubernetes services unless explicitly allowed by SMI policies. This behavior can be overridden with the `--set OpenServiceMesh.enablePermissiveTrafficPolicy=true` flag on the `osm install` command, allowing SMI policies not to be enforced while allowing traffic and services to still take advantage of features such as mTLS-encrypted traffic, metrics, and tracing.
 
     For example SMI policies, please see the following examples:
     - [demo/deploy-traffic-specs.sh](https://github.com/openservicemesh/osm/blob/release-v0.9/demo/deploy-traffic-specs.sh)

--- a/content/docs/guides/ha_scale/high_availability.md
+++ b/content/docs/guides/ha_scale/high_availability.md
@@ -64,7 +64,7 @@ Components `osm-controller` and `osm-injector` allow for separate horizontal sca
 HPA will automatically scale up or down control plane pods based on the average target CPU utilization (%). 
 To enable HPA, use the following command
 ```
-osm install --set=OpenServiceMesh.<control_plane_pod>.autoScale.enable=true
+osm install --set OpenServiceMesh.<control_plane_pod>.autoScale.enable=true
 ```
 > Note: control_plane_pod can be `osmController` or `injector`
 
@@ -78,6 +78,6 @@ In order to prevent disruptions during planned outages, control plane pods `osm-
 
 To enable PDB, use the following command
 ```
-osm install --set=OpenServiceMesh.<control_plane_pod>.enablePodDisruptionBudget=true
+osm install --set OpenServiceMesh.<control_plane_pod>.enablePodDisruptionBudget=true
 ```
 > Note: control_plane_pod can be `osmController` or `injector`

--- a/content/docs/guides/observability/logs.md
+++ b/content/docs/guides/observability/logs.md
@@ -47,7 +47,7 @@ When enabled, Fluent Bit can collect these logs, process them and send them to a
 OSM provides log forwarding by optionally deploying a Fluent Bit sidecar to the OSM controller using the `--set OpenServiceMesh.enableFluentbit=true` flag during installation. The user can then define where OSM logs should be forwarded using any of the available [Fluent Bit output plugins](https://docs.fluentbit.io/manual/pipeline/outputs).
 
 ### Configuring Log Forwarding with Fluent Bit
-By default, the Fluent Bit sidecar is configured to simply send logs to the Fluent Bit container's stdout. If you have installed OSM with Fluent Bit enabled, you may access these logs using `kubectl logs -n osm-system <osm-controller-name> -c fluentbit-logger`. This command will also help you find how your logs are formatted in case you need to change your parsers and filters. 
+By default, the Fluent Bit sidecar is configured to simply send logs to the Fluent Bit container's stdout. If you have installed OSM with Fluent Bit enabled, you may access these logs using `kubectl logs -n osm-system <osm-controller-name> -c fluentbit-logger`. This command will also help you find how your logs are formatted in case you need to change your parsers and filters.
 
 To quickly bring up Fluent Bit with default values, use:
 ```console
@@ -85,7 +85,7 @@ Fluent Bit has an Azure output plugin that can be used to send logs to an Azure 
 
 2. Navigate to your new workspace in Azure Portal. Find your Workspace ID and Primary key in your workspace under Agents management. In `values.yaml`, under `fluentBit`, update the `outputPlugin` to `azure` and keys `workspaceId` and `primaryKey` with the corresponding values from Azure Portal (without quotes). Alternatively, you may replace entire output section in `fluentbit-configmap.yaml` as you would for any other output plugin.
 
-3. Run through steps 2-5 above. 
+3. Run through steps 2-5 above.
 
 4. Once you run OSM with Fluent Bit enabled, logs will populate under the Logs > Custom Logs section in your Log Analytics workspace. There, you may run the following query to view most recent logs first:
     ```
@@ -114,7 +114,11 @@ You may require outbound proxy support if your egress traffic is configured to g
 
 If you have already built OSM with the MeshConfig changes above, you can simply enable proxy support using the OSM CLI, replacing your values in the command below:
 ```
-osm install --set OpenServiceMesh.enableFluentbit=true,OpenServiceMesh.fluentBit.enableProxySupport=true,OpenServiceMesh.fluentBit.httpProxy=<http-proxy-host:port>,OpenServiceMesh.fluentBit.httpsProxy=<https-proxy-host:port>
+osm install \
+    --set OpenServiceMesh.enableFluentbit=true \
+    --set ServiceMesh.fluentBit.enableProxySupport=true \
+    --set ServiceMesh.fluentBit.httpProxy=<http-proxy-host:port> \
+    --set ServiceMesh.fluentBit.httpsProxy=<https-proxy-host:port>
 ```
 
 Alternatively, you may change the values in the Helm chart by updating the following in `values.yaml`:

--- a/content/docs/guides/observability/logs.md
+++ b/content/docs/guides/observability/logs.md
@@ -44,14 +44,14 @@ When enabled, Fluent Bit can collect these logs, process them and send them to a
 
 [Fluent Bit](https://fluentbit.io/) is an open source log processor and forwarder which allows you to collect data/logs and send them to multiple destinations. It can be used with OSM to forward OSM controller logs to a variety of outputs/log consumers by using its output plugins.
 
-OSM provides log forwarding by optionally deploying a Fluent Bit sidecar to the OSM controller using the `--set=OpenServiceMesh.enableFluentbit=true` flag during installation. The user can then define where OSM logs should be forwarded using any of the available [Fluent Bit output plugins](https://docs.fluentbit.io/manual/pipeline/outputs).
+OSM provides log forwarding by optionally deploying a Fluent Bit sidecar to the OSM controller using the `--set OpenServiceMesh.enableFluentbit=true` flag during installation. The user can then define where OSM logs should be forwarded using any of the available [Fluent Bit output plugins](https://docs.fluentbit.io/manual/pipeline/outputs).
 
 ### Configuring Log Forwarding with Fluent Bit
 By default, the Fluent Bit sidecar is configured to simply send logs to the Fluent Bit container's stdout. If you have installed OSM with Fluent Bit enabled, you may access these logs using `kubectl logs -n osm-system <osm-controller-name> -c fluentbit-logger`. This command will also help you find how your logs are formatted in case you need to change your parsers and filters. 
 
 To quickly bring up Fluent Bit with default values, use:
 ```console
-osm install --set=OpenServiceMesh.enableFluentbit=true
+osm install --set OpenServiceMesh.enableFluentbit=true
 ```
 By default, logs will be filtered to emit info level logs. You may change the log level to "debug", "warn", "fatal", "panic", "disabled" or "trace" during installation using `--set OpenServiceMesh.controllerLogLevel=<desired log level>` . To get _all_ logs, set the log level to trace.
 
@@ -74,7 +74,7 @@ To customize log forwarding to your output, follow these steps and then reinstal
 
 1. Once you have updated the Fluent Bit ConfigMap template, you can deploy Fluent Bit during OSM installation using:
     ```console
-    osm install --set=OpenServiceMesh.enableFluentbit=true [--set OpenServiceMesh.controllerLogLevel=<desired log level>]
+    osm install --set OpenServiceMesh.enableFluentbit=true [--set OpenServiceMesh.controllerLogLevel=<desired log level>]
     ```
     You should now be able to interact with error logs in the output of your choice as they get generated.
 
@@ -114,7 +114,7 @@ You may require outbound proxy support if your egress traffic is configured to g
 
 If you have already built OSM with the MeshConfig changes above, you can simply enable proxy support using the OSM CLI, replacing your values in the command below:
 ```
-osm install --set=OpenServiceMesh.enableFluentbit=true,OpenServiceMesh.fluentBit.enableProxySupport=true,OpenServiceMesh.fluentBit.httpProxy=<http-proxy-host:port>,OpenServiceMesh.fluentBit.httpsProxy=<https-proxy-host:port>
+osm install --set OpenServiceMesh.enableFluentbit=true,OpenServiceMesh.fluentBit.enableProxySupport=true,OpenServiceMesh.fluentBit.httpProxy=<http-proxy-host:port>,OpenServiceMesh.fluentBit.httpsProxy=<https-proxy-host:port>
 ```
 
 Alternatively, you may change the values in the Helm chart by updating the following in `values.yaml`:
@@ -129,6 +129,6 @@ Alternatively, you may change the values in the Helm chart by updating the follo
 
 1. Install OSM with Fluent Bit enabled:
     ```console
-    osm install --set=OpenServiceMesh.enableFluentbit=true
+    osm install --set OpenServiceMesh.enableFluentbit=true
     ```
 > NOTE: Ensure that the [Fluent Bit image tag](https://github.com/openservicemesh/osm/blob/release-v0.9/charts/osm/values.yaml) is `1.6.4` or greater as it is required for this feature.

--- a/content/docs/guides/observability/metrics.md
+++ b/content/docs/guides/observability/metrics.md
@@ -29,13 +29,13 @@ to automatically provision the metrics components and with the BYO method.
 
 By default, both Prometheus and Grafana are disabled.
 
-However, when configured with the `--set=OpenServiceMesh.deployPrometheus=true` flag, OSM installation will deploy a Prometheus instance to scrape the sidecar's metrics endpoints. Based on the metrics scraping configuration set by the user, OSM will annotate pods part of the mesh with necessary metrics annotations to have Prometheus reach and scrape the pods to collect relevant metrics. To install Grafana for metrics visualization, set the `--set=OpenServiceMesh.deployGrafana=true` flag to true when installing OSM using the `osm install` command.
+However, when configured with the `--set OpenServiceMesh.deployPrometheus=true` flag, OSM installation will deploy a Prometheus instance to scrape the sidecar's metrics endpoints. Based on the metrics scraping configuration set by the user, OSM will annotate pods part of the mesh with necessary metrics annotations to have Prometheus reach and scrape the pods to collect relevant metrics. To install Grafana for metrics visualization, set the `--set OpenServiceMesh.deployGrafana=true` flag to true when installing OSM using the `osm install` command.
 
 The automatic bring up can be overridden with the `osm install --set` flag during install time:
 
 ```bash
- osm install --set=OpenServiceMesh.deployPrometheus=true \
-             --set=OpenServiceMesh.deployGrafana=true
+ osm install --set OpenServiceMesh.deployPrometheus=true \
+             --set OpenServiceMesh.deployGrafana=true
 ```
 
 Note that the Prometheus and Grafana instances deployed automatically by OSM have simple configurations that do not include high availability, persistent storage, or locked down security. If production-grade instances are required, pre-provision them and follow the BYO instructions on this page to integrate them with OSM.

--- a/content/docs/guides/observability/tracing.md
+++ b/content/docs/guides/observability/tracing.md
@@ -22,13 +22,13 @@ OSM CLI offers the capability to deploy a Jaeger instance with OSM's installatio
 ### Automatically Provision Jaeger
 By default, Jaeger deployment and tracing as a whole is disabled.
 
-A Jaeger instance can be automatically deployed by using the `--set=OpenServiceMesh.deployJaeger=true` OSM CLI flag at install time. This will provision a Jaeger pod in the mesh namespace.
+A Jaeger instance can be automatically deployed by using the `--set OpenServiceMesh.deployJaeger=true` OSM CLI flag at install time. This will provision a Jaeger pod in the mesh namespace.
 
 Additionally, OSM has to be instructed to enable tracing on the proxies; this is done via the `tracing` section on the MeshConfig.
 
 The following command will both deploy Jaeger and configure the tracing parameters according to the address of the newly deployed instance of Jaeger during OSM installation:
 ```bash
-osm install --set=OpenServiceMesh.deployJaeger=true,OpenServiceMesh.tracing.enable=true
+osm install --set OpenServiceMesh.deployJaeger=true,OpenServiceMesh.tracing.enable=true
 ```
 
 This default bring-up uses the [All-in-one Jaeger executable](https://www.jaegertracing.io/docs/1.22/getting-started/#all-in-one) that launches the Jaeger UI, collector, query, and agent.

--- a/content/docs/guides/troubleshooting/grafana.md
+++ b/content/docs/guides/troubleshooting/grafana.md
@@ -11,7 +11,7 @@ If a Grafana instance installed with OSM can't be reached, perform the following
 
 1. Verify a Grafana Pod exists.
 
-    When installed with `osm install --set=OpenServiceMesh.deployGrafana=true`, a Grafana Pod named something like `osm-grafana-7c88b9687d-tlzld` should exist in the namespace of the other OSM control plane components which named `osm-system` by default.
+    When installed with `osm install --set OpenServiceMesh.deployGrafana=true`, a Grafana Pod named something like `osm-grafana-7c88b9687d-tlzld` should exist in the namespace of the other OSM control plane components which named `osm-system` by default.
 
     If no such Pod is found, verify the OSM Helm chart was installed with the `OpenServiceMesh.deployGrafana` parameter set to `true` with `helm`:
 
@@ -19,7 +19,7 @@ If a Grafana instance installed with OSM can't be reached, perform the following
     $ helm get values -a <mesh name> -n <OSM namespace>
     ```
 
-    If the parameter is set to anything but `true`, reinstall OSM with the `--set=OpenServiceMesh.deployGrafana=true` flag on `osm install`.
+    If the parameter is set to anything but `true`, reinstall OSM with the `--set OpenServiceMesh.deployGrafana=true` flag on `osm install`.
 
 1. Verify the Grafana Pod is healthy.
 

--- a/content/docs/guides/troubleshooting/prometheus.md
+++ b/content/docs/guides/troubleshooting/prometheus.md
@@ -12,7 +12,7 @@ If a Prometheus instance installed with OSM can't be reached, perform the follow
 
 1. Verify a Prometheus Pod exists.
 
-    When installed with `osm install --set=OpenServiceMesh.deployPrometheus=true`, a Prometheus Pod named something like `osm-prometheus-5794755b9f-rnvlr` should exist in the namespace of the other OSM control plane components which named `osm-system` by default.
+    When installed with `osm install --set OpenServiceMesh.deployPrometheus=true`, a Prometheus Pod named something like `osm-prometheus-5794755b9f-rnvlr` should exist in the namespace of the other OSM control plane components which named `osm-system` by default.
 
     If no such Pod is found, verify the OSM Helm chart was installed with the `OpenServiceMesh.deployPrometheus` parameter set to `true` with `helm`:
 
@@ -20,7 +20,7 @@ If a Prometheus instance installed with OSM can't be reached, perform the follow
     $ helm get values -a <mesh name> -n <OSM namespace>
     ```
 
-    If the parameter is set to anything but `true`, reinstall OSM with the `--set=OpenServiceMesh.deployPrometheus=true` flag on `osm install`.
+    If the parameter is set to anything but `true`, reinstall OSM with the `--set OpenServiceMesh.deployPrometheus=true` flag on `osm install`.
 
 1. Verify the Prometheus Pod is healthy.
 


### PR DESCRIPTION
Following the docs I used this to install OSM:
```bash
./osm install \
    --set=OpenServiceMesh.osmController.autoScale.enable=true \
    --set=OpenServiceMesh.osmController.autoScale.minReplicas=3 \
    --set=OpenServiceMesh.osmController.autoScale.maxReplicas=99 \
    --set=OpenServiceMesh.osmController.autoScale.targetAverageUtilization=75 \
    --set=OpenServiceMesh.osmController.enablePodDisruptionBudget=true \
    --set=OpenServiceMesh.injector.autoScale.enable=true \
    --set=OpenServiceMesh.injector.autoScale.minReplicas=3 \
    --set=OpenServiceMesh.injector.autoScale.maxReplicas=99 \
    --set=OpenServiceMesh.injector.autoScale.targetAverageUtilization=75 \
    --set=OpenServiceMesh.injector.enablePodDisruptionBudget=true
```

To my surprise the number of Controller and Injector pods remained 1. Additionally - I used `99` as max and this did **not** result in an error.

Then I changed the command to this and it resulted in multiple replicas (and an error for 99, which I changed to 10)
```bash
./osm install \
    --set OpenServiceMesh.osmController.autoScale.enable=true \
    --set OpenServiceMesh.osmController.autoScale.minReplicas=3 \
    --set OpenServiceMesh.osmController.autoScale.maxReplicas=10 \
    --set OpenServiceMesh.osmController.autoScale.targetAverageUtilization=75 \
    --set OpenServiceMesh.osmController.enablePodDisruptionBudget=true \
    --set OpenServiceMesh.injector.autoScale.enable=true \
    --set OpenServiceMesh.injector.autoScale.minReplicas=3 \
    --set OpenServiceMesh.injector.autoScale.maxReplicas=10 \
    --set OpenServiceMesh.injector.autoScale.targetAverageUtilization=75 \
    --set OpenServiceMesh.injector.enablePodDisruptionBudget=true
```

This tells me that we should be using `--set Open....` and not `--set=Open...`

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>