### PR TITLE
Redirect docs.openservicemesh.io to point to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 
 docs.openservicemesh.io is a static site. The documentation content needs to be located at `content/docs/`.
 
-The content served on [https://docs.openservicemesh.io](https://docs.openservicemesh.io) is served from the main branch of this repo. Most updates should be made only in main.
+The content served on [https://docs.openservicemesh.io](https://docs.openservicemesh.io) is served from the latest release on this repo. Most updates should be made only in main and can
+be previewed at [https://main--osm-docs.netlify.app/](https://main--osm-docs.netlify.app/).
 
 If it's necessary to change published release-specific docs, those changes should be made in the release-specific branch serving those docs. Once configured as described in [Adding release-specific docs](#adding-release-specific-docs), PRs to that branch will auto-build just like PRs to main.
 
@@ -30,19 +31,59 @@ type: docs
 ## Front Matter Notes:
 
 * inclusion of `type: docs` is important for the theme to properly index the site contents
-* the `linkTitle` attribute allows you to simplify the name as it appears in the left-side nav bar - ideally it should be short and clear - whereas the title can handle longform names for pages/documents.
+* the `linkTitle` attribute allows you to simplify the name as it appears in the left-side nav bar - ideally it should be short and clear - whereas the title can handle long form names for pages/documents.
 
 ## Adding release-specific docs
 
-Steps to add a release-specific version of the docs site:
+### Create a release branch
 
-1. Create a release branch from `main` in your fork of this repo. Name this new branch after the released major and minor version, like [release-v0.8](https://github.com/openservicemesh/osm-docs/tree/release-v0.8).
-1. Update the site's config.toml file in your branch to reflect the release version - add [these params](https://github.com/openservicemesh/osm-docs/blob/release-v0.8/config.toml#L99L101) to enable the banner at the top of the site that will tell visitors which version they are looking at.
-1. List the new branch in the [config.toml](https://github.com/openservicemesh/osm-docs/blob/main/config.toml#L84-L89) for all currently-displayed versions.
-1. Push your newly-created `release-X.Y` branch upstream to this repo on GitHub in order for the new branch to be usable by Netlify
-1. Netlify will auto-deploy the branch to a url like [https://release-v0-8--osm-docs.netlify.app/](https://release-v0-8--osm-docs.netlify.app/). Use this to preview and test that this branch builds correctly.
-1. Open an issue in this repo asking for a new DNS record be added to the site (via Netlify), to assign a subdomain to the deployed branch.
-1. When published, the newly-added branch will function like [https://release-v0-8.docs.openservicemesh.io/](https://release-v0-8.docs.openservicemesh.io/)
+Look for a branch in the upstream repo named `release-vX.Y`, where `X` and `Y` correspond to the major and minor version of the new release. For example, [release-v0.8](https://github.com/openservicemesh/osm-docs/tree/release-v0.8). If the branch already exists, move to the next step.
+
+Identify the base commit in the main branch for the release and cut a release branch off main.
+
+> Note: Care must be taken to ensure the release branch is created from a commit meant for the release. If unsure about the commit to use to create the release branch, please open an issue in the osm repo and a maintainer will assist you with this.
+
+```console
+$ git checkout -b release-<version> <commit-id> # ex: git checkout -b release-v0.4 0d05587
+```
+
+Push the release branch to the upstream repo (NOT forked), identified here by the upstream remote.
+
+```console
+$ git push upstream release-<version> # ex: git push upstream release-v0.4
+```
+
+Netlify will auto-deploy the branch to a url like [https://release-v0-8--osm-docs.netlify.app/](https://release-v0-8--osm-docs.netlify.app/). This can be used to preview and test that the branch builds correctly.
+
+### Update the release branch
+
+1. Create a new branch off of the release branch to maintain updates specific to the new version. Let's call it the patch branch. The patch branch should not be created in the upstream repo.
+2. On the patch branch, add the new release as a version parameter in [config.toml](https://github.com/openservicemesh/osm-docs/blob/main/config.toml#L84-L89) with the `latest` tag. The version parameters represent all currently supported versions of OSM and are used to populate the Release drop down menu on the site. The url for the new release is formatted `https://release-vX-Y.docs.openservicemesh.io/`.
+
+    ```toml
+    [[params.versions]]
+        version = "v0.8 (latest)"
+        url = "https://release-v0-8.docs.openservicemesh.io/"
+    ```
+
+3. Create a pull request from the patch branch to the release branch. Proceed to the next step once the pull request is approved and merged.
+4. Open an issue in this repo asking for a new DNS record be added to the site (via Netlify), to assign a subdomain to the deployed branch.
+5. When published, the newly-added branch will function like [https://release-v0-8.docs.openservicemesh.io/](https://release-v0-8.docs.openservicemesh.io/)
+
+### After publishing the new release-specific docs
+
+1. Update the `redirects` in `netlify.toml` on the main branch to redirect `https://docs.openservicemesh.io/` to `https//release-vX-Y.docs.openservicemesh.io/` where `release-vX-Y` is the newest release.
+2. Each previous release-specific site that is still supported needs to be able to access the latest release from the Release drop down. On the previous release branches, update the [config.toml](https://github.com/openservicemesh/osm-docs/blob/main/config.toml#L84-L89) to list the new release version as shown above.
+3. The `latest` tag must be removed from all previous versions. For example, the `latest` tag must be removed from `v0.7 (latest)` on the `release-v0.7` branch.
+4. Add [banner.html](https://github.com/openservicemesh/osm-docs/blob/release-v0.9/themes/dosmy/layouts/partials/banner.html) to the previous latest release branch.
+5. Add or update version banner parameter in `config.toml` to enable the banner at the top of each previous release-specific site that will tell visitors which version they are looking at. For example, the version banner for `release-v0-7` would be configured as follows:
+
+    ```toml
+    [params.versionbanner]
+	    show = true
+	    archive = "v0.7"
+	    latest = "https://release-v0-8.docs.openservicemesh.io/"
+    ```
 
 
 # Site Development
@@ -56,8 +97,8 @@ Steps to add a release-specific version of the docs site:
 
 ## Install dependencies:
 
-* Hugo [installation guide](https://gohugo.io/getting-started/installing/)  
-* NPM packages are installed by running `yarn`. [Install Yarn](https://yarnpkg.com/getting-started/install) if you need to.  
+* Hugo [installation guide](https://gohugo.io/getting-started/installing/)
+* NPM packages are installed by running `yarn`. [Install Yarn](https://yarnpkg.com/getting-started/install) if you need to.
 
 ## Run the site:
 
@@ -74,7 +115,7 @@ hugo serve
 
 ## Deploying the site:
 
-The site auto deploys the main branch via [Netlify](https://app.netlify.com/sites/osm-docs). Once pull requests are merged the changes will appear at docs.openservicemesh.io after a couple of minutes. Check the [logs](https://app.netlify.com/sites/osm-docs/deploys) for details.
+The site auto deploys the main branch via [Netlify](https://app.netlify.com/sites/osm-docs/deploys). Once pull requests are merged the changes will appear at docs.openservicemesh.io after a couple of minutes. Check the [logs](https://app.netlify.com/sites/osm-docs/deploys) for details.
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/8c8b7b52-b87f-42e0-949a-a784c3ca6d9a/deploy-status)](https://app.netlify.com/sites/osm-docs/deploys)
 

--- a/config.toml
+++ b/config.toml
@@ -82,10 +82,7 @@ prism_syntax_highlighting = true
 project_home = "https://openservicemesh.io/"
 
 [[params.versions]]
-  version = "latest (unreleased)"
-  url = "https://docs.openservicemesh.io/"
-[[params.versions]]
-  version = "v0.10"
+  version = "v0.10 (latest)"
   url = "https://release-v0-10.docs.openservicemesh.io/"
 [[params.versions]]
   version = "v0.9"

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,4 +10,5 @@
 
 [[redirects]]
   from = "https://docs.openservicemesh.io/"
-  to = "https://docs.openservicemesh.io/docs/"
+  to = "https://release-v0-10.docs.openservicemesh.io/"
+  force = true


### PR DESCRIPTION
Makes docs.openservicemesh.io point to the latest released version
and not unreleased version. Removes unreleased versions from the
site. Changes on main can instead be previewed using Netlify.
Updates docs for creating a release specific site.

Resolves #191.

Signed-off-by: jaellio <jaellio@microsoft.com>