### PR TITLE
Update v0.9 for latest release v0.10

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -82,8 +82,8 @@ prism_syntax_highlighting = true
 project_home = "https://openservicemesh.io/"
 
 [[params.versions]]
-  version = "latest"
-  url = "https://docs.openservicemesh.io/"
+  version = "v0.10 (latest)"
+  url = "https://release-v0-10.docs.openservicemesh.io/"
 [[params.versions]]
   version = "v0.9"
   url = "https://release-v0-9.docs.openservicemesh.io/"
@@ -93,7 +93,7 @@ project_home = "https://openservicemesh.io/"
 [params.versionbanner]
 	show = true
 	archive = "v0.9"
-	latest = "https://docs.openservicemesh.io/"
+	latest = "https://release-v0-10.docs.openservicemesh.io/"
 
 [params.ui]
 navbar_logo = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,4 +10,5 @@
 
 [[redirects]]
   from = "https://docs.openservicemesh.io/"
-  to = "https://docs.openservicemesh.io/docs/"
+  to = "https://release-v0-10.docs.openservicemesh.io/"
+  force = true

--- a/themes/dosmy/layouts/partials/banner.html
+++ b/themes/dosmy/layouts/partials/banner.html
@@ -1,9 +1,9 @@
 <div id="banner">
   <!-- viewing helm 3 version of site (desktop) -->
   <p class="center text-center d-none d-lg-block">
-    You are viewing docs for the {{ .Site.Params.versionbanner.archive }} release. View <a href="{{ .Site.Params.versionbanner.latest }}">main branch docs</a> for the latest changes.
+    You are viewing docs for the {{ .Site.Params.versionbanner.archive }} release. View the docs for the latest release <a href="{{ .Site.Params.versionbanner.latest }}">here</a>
   </p>
-  
+
   <!-- viewing helm 3 version of site (mobile) -->
   <p class="center text-center d-lg-none">
     Viewing {{ .Site.Params.versionbanner.archive }} docs. <a href="{{ .Site.Params.versionbanner.latest }}">Latest changes</a>.


### PR DESCRIPTION
Adds the v0.10 release specific branch to the version params and
updates the version banner to remove the reference to main.

Signed-off-by: jaellio <jaellio@microsoft.com>