### PR TITLE
Update v0.8 for latest release v0.10

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -88,8 +88,8 @@ breadcrumb_disable = false
 sidebar_search_disable = false
 
 [[params.versions]]
-  version = "latest"
-  url = "https://docs.openservicemesh.io/"
+  version = "v0.10 (latest)"
+  url = "https://release-v0-10.docs.openservicemesh.io/"
 [[params.versions]]
   version = "v0.9"
   url = "https://release-v0-9.docs.openservicemesh.io/"
@@ -99,7 +99,7 @@ sidebar_search_disable = false
 [params.versionbanner]
 	show = true
 	archive = "v0.8"
-	latest = "https://docs.openservicemesh.io/"
+	latest = "https://release-v0-10.docs.openservicemesh.io/"
 
 
 [params.ui.feedback]

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,4 +10,5 @@
 
 [[redirects]]
   from = "https://docs.openservicemesh.io/"
-  to = "https://docs.openservicemesh.io/docs/"
+  to = "https://release-v0-10.docs.openservicemesh.io/"
+  force = true

--- a/themes/dosmy/layouts/partials/banner.html
+++ b/themes/dosmy/layouts/partials/banner.html
@@ -1,9 +1,9 @@
 <div id="banner">
   <!-- viewing helm 3 version of site (desktop) -->
   <p class="center text-center d-none d-lg-block">
-    You are viewing docs for the {{ .Site.Params.versionbanner.archive }} release. View <a href="{{ .Site.Params.versionbanner.latest }}">main branch docs</a> for the latest changes.
+    You are viewing docs for the {{ .Site.Params.versionbanner.archive }} release. View the docs for the latest release <a href="{{ .Site.Params.versionbanner.latest }}">here</a>
   </p>
-  
+
   <!-- viewing helm 3 version of site (mobile) -->
   <p class="center text-center d-lg-none">
     Viewing {{ .Site.Params.versionbanner.archive }} docs. <a href="{{ .Site.Params.versionbanner.latest }}">Latest changes</a>.


### PR DESCRIPTION
Adds the v0.10 release specific branch to the version params and
updates the version banner to remove the reference to main. Adds
redirect to v0.10.

Signed-off-by: jaellio <jaellio@microsoft.com>