### PR TITLE
Update v0.10 as latest release

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -82,10 +82,7 @@ prism_syntax_highlighting = true
 project_home = "https://openservicemesh.io/"
 
 [[params.versions]]
-  version = "latest (unreleased)"
-  url = "https://docs.openservicemesh.io/"
-[[params.versions]]
-  version = "v0.10"
+  version = "v0.10 (latest)"
   url = "https://release-v0-10.docs.openservicemesh.io/"
 [[params.versions]]
   version = "v0.9"

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,4 +10,5 @@
 
 [[redirects]]
   from = "https://docs.openservicemesh.io/"
-  to = "https://docs.openservicemesh.io/docs/"
+  to = "https://release-v0-10.docs.openservicemesh.io/"
+  force = true


### PR DESCRIPTION
Adds redirect to latest release. Updates release drop down menu to
remove unreleased option and tag v0.10 with latest.

Signed-off-by: jaellio <jaellio@microsoft.com>