### PR TITLE
release-v0.11: update redirects and release menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -82,10 +82,7 @@ prism_syntax_highlighting = true
 project_home = "https://openservicemesh.io/"
 
 [[params.versions]]
-  version = "latest (unreleased)"
-  url = "https://docs.openservicemesh.io/"
-[[params.versions]]
-  version = "v0.11"
+  version = "v0.11 (latest)"
   url = "https://release-v0-11.docs.openservicemesh.io/"
 [[params.versions]]
   version = "v0.10"

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,4 +10,5 @@
 
 [[redirects]]
   from = "https://docs.openservicemesh.io/"
-  to = "https://docs.openservicemesh.io/docs/"
+  to = "https://release-v0-11.docs.openservicemesh.io/"
+  force = true


### PR DESCRIPTION
Updates the docs url redirect and adds the latest tag to v0.11 in
the Release drop down menu.

Signed-off-by: jaellio <jaellio@microsoft.com>