### PR TITLE
ensure search results are visible

### DIFF
--- a/themes/dosmy/assets/js/offline-search.js
+++ b/themes/dosmy/assets/js/offline-search.js
@@ -11,11 +11,17 @@
         //
 
         $searchInput.data('html', true);
-        $searchInput.data('placement', 'bottom');
         $searchInput.data(
             'template',
-            '<div class="popover offline-search-result" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>'
+            '<div class="popover offline-search-result" role="tooltip"><h3 class="popover-header"></h3><div class="popover-body"></div></div>'
         );
+        $searchInput.data('popperConfig', {
+            modifiers: {
+                preventOverflow: {
+                    boundariesElement: 'viewport'
+                }
+            }
+        });
 
         //
         // Register handler

--- a/themes/dosmy/assets/scss/_search.scss
+++ b/themes/dosmy/assets/scss/_search.scss
@@ -17,9 +17,6 @@
 }
 
 .popover.offline-search-result {
-    // Override bootstrap default style (max-width: $popover-max-width;)
-    max-width: 90%;
-
     .card {
         margin-bottom: $spacer * .5;
 

--- a/themes/dosmy/assets/scss/main.scss
+++ b/themes/dosmy/assets/scss/main.scss
@@ -524,13 +524,10 @@ footer {
 
 .popover {
   margin: 0;
-  top: 10.5rem !important;
-  left: 0 !important;
-  right: 10vw !important;
-  bottom: 0 !important;
+  right: 10vw;
+  bottom: 0;
   min-width: 33vw;
-  max-width: 600px !important;
-  position: fixed !important;
+  max-width: 600px;
   box-shadow: 0 5px 12px 11999px rgba(60,60,60,0.5);
 
   .popover-body {


### PR DESCRIPTION
Previously, search results would scroll off the page when the main was
scrolled down far enough. Searching while already scrolled down far
enough would hide search results until the page was scrolled toward the
top. These changes make the search results visible regardless of
vertical position within the main content.

Fixes #182