### PR TITLE
fix sidebar formatting on homepage

### DIFF
--- a/themes/dosmy/layouts/partials/sidebar-tree.html
+++ b/themes/dosmy/layouts/partials/sidebar-tree.html
@@ -23,7 +23,7 @@
       {{ partial "navbar-lang-selector.html" . }}
     </div>
     {{ end }}
-    {{ template "section-tree-nav-section" (dict "page" . "section" .FirstSection "delayActive" $shouldDelayActive)  }}
+    {{ template "section-tree-nav-section" (dict "page" . "section" (index .Site.Sections 0) "delayActive" $shouldDelayActive)  }}
   </nav>
 </div>
 {{ define "section-tree-nav-section" }}


### PR DESCRIPTION
This change makes the sidebar on the homepage look just like it does on
the other pages.

Fixes #196