### PR TITLE
Parameterize release versions

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -81,6 +81,11 @@ algolia_docsearch = false
 prism_syntax_highlighting = true
 project_home = "https://openservicemesh.io/"
 
+# Version params
+osm_branch = "main"
+osm_version = "v0.11.0"
+envoy_version = "v1.19.1"
+
 [[params.versions]]
   version = "v0.11 (latest)"
   url = "https://release-v0-11.docs.openservicemesh.io/"

--- a/content/docs/demos/prometheus_grafana.md
+++ b/content/docs/demos/prometheus_grafana.md
@@ -41,7 +41,7 @@ Let's replace the configuration of `stable-prometheus-server`
 kubectl edit configmap stable-prometheus-server
 ```
 
-Now with your editor of choice, look for the `prometheus.yaml` key entry and replace it with [OSM's scraping config](https://github.com/openservicemesh/osm/blob/release-v0.9/charts/osm/templates/prometheus-configmap.yaml) (proceed with care while formatting the yaml file):
+Now with your editor of choice, look for the `prometheus.yaml` key entry and replace it with [OSM's scraping config](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/charts/osm/templates/prometheus-configmap.yaml) (proceed with care while formatting the yaml file):
 ```
   (....)
   prometheus.yml: |
@@ -317,7 +317,7 @@ Saving and testing at this stage should already be enough, and Grafana should te
 
 ## Importing OSM Dashboards
 OSM Dashboards are available both through:
-- [our repository](https://github.com/openservicemesh/osm/tree/release-v0.9/charts/osm/grafana), and are importable as json blobs through the web admin portal
+- [our repository](https://github.com/openservicemesh/osm/tree/{{< param osm_branch >}}/charts/osm/grafana), and are importable as json blobs through the web admin portal
 - or [online at Grafana.com](https://grafana.com/grafana/dashboards/14145)
 
 To import a dashboard, look for the `+` sign on the left menu and select `import`.

--- a/content/docs/getting_started/setup_osm.md
+++ b/content/docs/getting_started/setup_osm.md
@@ -8,7 +8,7 @@ weight: 1
 # Setup OSM
 
 ## Prerequisites
-This demo of OSM v0.9.2 requires:
+This demo of OSM {{< param osm_version >}} requires:
   - a cluster running Kubernetes v1.19 or greater (using a cloud provider of choice, [minikube](https://minikube.sigs.k8s.io/docs/start/), or similar)
   - a workstation capable of executing [Bash](https://en.wikipedia.org/wiki/Bash_(Unix_shell)) scripts
   - [The Kubernetes command-line tool](https://kubernetes.io/docs/tasks/tools/#kubectl) - `kubectl`
@@ -25,19 +25,19 @@ The binary is available on the [OSM GitHub releases page](https://github.com/ope
 
 ### For GNU/Linux and macOS
 
-Download the 64-bit GNU/Linux or macOS binary of OSM v0.9.2:
+Download the 64-bit GNU/Linux or macOS binary of OSM {{< param osm_version >}}:
 ```bash
 system=$(uname -s)
-release=v0.9.2
+release={{< param osm_version >}}
 curl -L https://github.com/openservicemesh/osm/releases/download/${release}/osm-${release}-${system}-amd64.tar.gz | tar -vxzf -
 ./${system}-amd64/osm version
 ```
 
 ### For Windows
 
-Download the 64-bit Windows OSM v0.9.2 binary via Powershell:
+Download the 64-bit Windows OSM {{< param osm_version >}} binary via Powershell:
 ```powershell
-wget  https://github.com/openservicemesh/osm/releases/download/v0.9.2/osm-v0.9.2-windows-amd64.zip -o osm.zip
+wget  https://github.com/openservicemesh/osm/releases/download/{{< param osm_version >}}/osm-{{< param osm_version >}}-windows-amd64.zip -o osm.zip
 unzip osm.zip
 .\windows-amd64\osm.exe version
 ```

--- a/content/docs/guides/app_onboarding/_index.md
+++ b/content/docs/guides/app_onboarding/_index.md
@@ -15,19 +15,19 @@ The following guide describes how to onboard a Kubernetes microservice to an OSM
     OSM conforms to the SMI specification. By default, OSM denies all traffic communications between Kubernetes services unless explicitly allowed by SMI policies. This behavior can be overridden with the `--set=OpenServiceMesh.enablePermissiveTrafficPolicy=true` flag on the `osm install` command, allowing SMI policies not to be enforced while allowing traffic and services to still take advantage of features such as mTLS-encrypted traffic, metrics, and tracing.
 
     For example SMI policies, please see the following examples:
-    - [demo/deploy-traffic-specs.sh](https://github.com/openservicemesh/osm/blob/release-v0.9/demo/deploy-traffic-specs.sh)
-    - [demo/deploy-traffic-split.sh](https://github.com/openservicemesh/osm/blob/release-v0.9/demo/deploy-traffic-split.sh)
-    - [demo/deploy-traffic-target.sh](https://github.com/openservicemesh/osm/blob/release-v0.9/demo/deploy-traffic-target.sh)
+    - [demo/deploy-traffic-specs.sh](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/demo/deploy-traffic-specs.sh)
+    - [demo/deploy-traffic-split.sh](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/demo/deploy-traffic-split.sh)
+    - [demo/deploy-traffic-target.sh](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/demo/deploy-traffic-target.sh)
 
 1. If an application in the mesh needs to communicate with the Kubernetes API server, the user needs to explicitly allow this either by using IP range exclusion or by creating an egress policy as outlined below.
-   
+
    First get the Kubernetes API server cluster IP:
    ```console
    $ kubectl get svc -n default
    NAME         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
    kubernetes   ClusterIP   10.0.0.1     <none>        443/TCP   1d
    ```
-   
+
     **Option 1:** add the Kubernetes API server's address to the list of Global outbound IP ranges for exclusion. The IP address could be a cluster IP address or a public IP address and should be appropriately excluded for connectivity to the Kubernetes API server.
 
     Add this IP to the MeshConfig so that outbound traffic to it is excluded from interception by OSM's sidecar:

--- a/content/docs/guides/certificates.md
+++ b/content/docs/guides/certificates.md
@@ -17,10 +17,10 @@ There are a few kinds of certificates used in OSM:
 
 | Cert Type                  | Where it is issued                                                                                                                                                                                     | How it is used                                                                                                                                                              | Validity duration                                                                                                              | Sample CommonName                                             |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| xDS bootstrap              | [pkg/injector/patch.go → createPatch()](https://github.com/openservicemesh/osm/blob/release-v0.9/pkg/injector/patch.go#L25-L28)                                                                        | used for [Envoy-to-xDS connections](https://github.com/openservicemesh/osm/blob/release-v0.9/pkg/envoy/ads/stream.go#L27); identifies Envoy (Pod) to the xDS control plane. | [XDSCertificateValidityPeriod](https://github.com/openservicemesh/osm/blob/release-v0.9/pkg/constants/constants.go) → a decade | `7b2359d7-f201-4d3f-a217-73fd6e44e39b.bookstore-v2.bookstore` |
-| service                    | [pkg/envoy/sds/response.go → createDiscoveryResponse()](https://github.com/openservicemesh/osm/blob/release-v0.9/pkg/envoy/secrets/types.go#L39)                                                       | used for east-west communication between Envoys; identifies Service Accounts                                                                                                | [defined in MeshConfig; default 24h](https://github.com/openservicemesh/osm/blob/release-v0.9/charts/osm/values.yaml#L82)      | `bookstore-v2.bookstore.cluster.local`                        |
-| mutating webhook handler   | [pkg/injector/webhook.go → NewWebhook()](https://github.com/openservicemesh/osm/blob/release-v0.9/pkg/injector/webhook.go#L67-L69)                                                                     | used by the webhook handler; **note**: this cert does not have to be related to the Envoy certs, but it does have to match the CA in the MutatingWebhookConfiguration       | [XDSCertificateValidityPeriod](https://github.com/openservicemesh/osm/blob/release-v0.9/pkg/constants/constants.go) → a decade | `osm-controller.osm-system.svc`                               |
-| validating webhook handler | [pkg/configurator/validating_webhook.go → NewValidatingWebhook()](https://github.com/openservicemesh/osm/blob/a48de43463c99c03e3662670bf7f2b99166e1388/pkg/configurator/validating_webhook.go#L85-L86) | used by the validating webhook handler; (same note as MWH cert)                                                                                                             | [XDSCertificateValidityPeriod](https://github.com/openservicemesh/osm/blob/release-v0.9/pkg/constants/constants.go) → a decade | `osm-config-validator.osm-system.svc`                         |
+| xDS bootstrap              | [pkg/injector/patch.go → createPatch()](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/pkg/injector/patch.go#L25-L28)                                                                        | used for [Envoy-to-xDS connections](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/pkg/envoy/ads/stream.go#L27); identifies Envoy (Pod) to the xDS control plane. | [XDSCertificateValidityPeriod](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/pkg/constants/constants.go) → a decade | `7b2359d7-f201-4d3f-a217-73fd6e44e39b.bookstore-v2.bookstore` |
+| service                    | [pkg/envoy/sds/response.go → createDiscoveryResponse()](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/pkg/envoy/secrets/types.go#L39)                                                       | used for east-west communication between Envoys; identifies Service Accounts                                                                                                | [defined in MeshConfig; default 24h](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/charts/osm/values.yaml#L82)      | `bookstore-v2.bookstore.cluster.local`                        |
+| mutating webhook handler   | [pkg/injector/webhook.go → NewWebhook()](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/pkg/injector/webhook.go#L67-L69)                                                                     | used by the webhook handler; **note**: this cert does not have to be related to the Envoy certs, but it does have to match the CA in the MutatingWebhookConfiguration       | [XDSCertificateValidityPeriod](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/pkg/constants/constants.go) → a decade | `osm-controller.osm-system.svc`                               |
+| validating webhook handler | [pkg/configurator/validating_webhook.go → NewValidatingWebhook()](https://github.com/openservicemesh/osm/blob/a48de43463c99c03e3662670bf7f2b99166e1388/pkg/configurator/validating_webhook.go#L85-L86) | used by the validating webhook handler; (same note as MWH cert)                                                                                                             | [XDSCertificateValidityPeriod](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/pkg/constants/constants.go) → a decade | `osm-config-validator.osm-system.svc`                         |
 
 ### Root Certificate
 
@@ -40,11 +40,11 @@ data:
   private.key: <base64 encoded private key>
 ```
 
-For details and code where this is used see [osm-controller.go](https://github.com/openservicemesh/osm/blob/release-v0.9/cmd/osm-controller/osm-controller.go#L182-L183).
+For details and code where this is used see [osm-controller.go](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/cmd/osm-controller/osm-controller.go#L182-L183).
 
 ### Rotate the Root Certificate (Tresor)
 
-The self-signed root certificate, which is created via the Tresor package within OSM, will expire in a decade. To rotate the root cert, the following steps should be followed: 
+The self-signed root certificate, which is created via the Tresor package within OSM, will expire in a decade. To rotate the root cert, the following steps should be followed:
 
 1. Delete the `osm-ca-bundle` certificate in the osm namesapce
    ```console
@@ -83,14 +83,14 @@ For certificate providers other than Tresor, the process of rotating the root ce
 
 Open Service Mesh supports 4 methods of issuing certificates:
 
-- using an internal OSM package, called [Tresor](https://github.com/openservicemesh/osm/tree/release-v0.9/pkg/certificate/providers/tresor). This is the default for a first time installation.
+- using an internal OSM package, called [Tresor](https://github.com/openservicemesh/osm/tree/{{< param osm_branch >}}/pkg/certificate/providers/tresor). This is the default for a first time installation.
 - using [Hashicorp Vault](https://www.vaultproject.io/)
 - using [Azure Key Vault](https://azure.microsoft.com/en-us/services/key-vault/)
 - using [cert-manager](https://cert-manager.io)
 
 ### Using OSM's Tresor certificate issuer
 
-Open Service Mesh includes a package, [tresor](https://github.com/openservicemesh/osm/tree/release-v0.9/pkg/certificate/providers/tresor). This is a minimal implementation of the `certificate.Manager` interface. It issues certificates leveraging the `crypto` Go library, and stores these certificates as Kubernetes secrets.
+Open Service Mesh includes a package, [tresor](https://github.com/openservicemesh/osm/tree/{{< param osm_branch >}}/pkg/certificate/providers/tresor). This is a minimal implementation of the `certificate.Manager` interface. It issues certificates leveraging the `crypto` Go library, and stores these certificates as Kubernetes secrets.
 
 - To use the `tresor` package during development set `export CERT_MANAGER=tresor` in the `.env` file of this repo.
 
@@ -127,7 +127,7 @@ Additionally:
 
 Installation of Hashi Vault is out of scope for the Open Service Mesh project. Typically this is the responsibility of dedicated security teams. Documentation on how to deploy Vault securely and make it highly available is available on [Vault's website](https://learn.hashicorp.com/vault/getting-started/install).
 
-This repository does contain a [script (deploy-vault.sh)](https://github.com/openservicemesh/osm/tree/release-v0.9/demo/deploy-vault.sh), which is used to automate the deployment of Hashi Vault for continuous integration. This is strictly for development purposes only. Running the script will deploy Vault in a Kubernetes namespace defined by the `$K8S_NAMESPACE` environment variable in your [.env](https://github.com/openservicemesh/osm/blob/release-v0.9/.env.example) file. This script can be used for demonstration purposes. It requires the following environment variables:
+This repository does contain a [script (deploy-vault.sh)](https://github.com/openservicemesh/osm/tree/{{< param osm_branch >}}/demo/deploy-vault.sh), which is used to automate the deployment of Hashi Vault for continuous integration. This is strictly for development purposes only. Running the script will deploy Vault in a Kubernetes namespace defined by the `$K8S_NAMESPACE` environment variable in your [.env](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/.env.example) file. This script can be used for demonstration purposes. It requires the following environment variables:
 
 ```
 export K8S_NAMESPACE=osm-system-ns

--- a/content/docs/guides/cli.md
+++ b/content/docs/guides/cli.md
@@ -22,7 +22,7 @@ In a bash-based shell on Linux/macOS or [Windows Subsystem for Linux](https://do
 
 ```console
 # Specify the OSM version that will be leveraged throughout these instructions
-OSM_VERSION=v0.9.1
+OSM_VERSION={{< param osm_version >}}
 
 # Linux curl command only
 curl -sL "https://github.com/openservicemesh/osm/releases/download/$OSM_VERSION/osm-$OSM_VERSION-linux-amd64.tar.gz" | tar -vxzf -
@@ -55,7 +55,7 @@ In a PowerShell-based shell on Windows, use `Invoke-WebRequest` to download the 
 
 ```console
 # Specify the OSM version that will be leveraged throughout these instructions
-$OSM_VERSION="v0.9.1"
+$OSM_VERSION="{{< param osm_version >}}"
 
 [Net.ServicePointManager]::SecurityProtocol = "tls12"
 $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -URI "https://github.com/openservicemesh/osm/releases/download/$OSM_VERSION/osm-$OSM_VERSION-windows-amd64.zip" -OutFile "osm-$OSM_VERSION.zip"

--- a/content/docs/guides/ha_scale/high_availability.md
+++ b/content/docs/guides/ha_scale/high_availability.md
@@ -17,7 +17,7 @@ High Availability and Fault Tolerance are implemented and ensured by several des
 
 OSM's control plane components do not own or have any state-dependent data that needs to be saved at runtime; with the controlled exceptions of:
 
-- CA / Root Certificate: The CA root certificate is required to be the same for multiple OSM instances when running multiple replica. For [Certificate Managers](https://github.com/openservicemesh/osm/blob/release-v0.9/DESIGN.md#2-certificate-manager) implementations that require the root CA to have been generated/provided prior OSM execution (Vault, Cert-Manager), the root CA will be fetched from the provider at boot by all instances.
+- CA / Root Certificate: The CA root certificate is required to be the same for multiple OSM instances when running multiple replica. For [Certificate Managers](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/DESIGN.md#2-certificate-manager) implementations that require the root CA to have been generated/provided prior OSM execution (Vault, Cert-Manager), the root CA will be fetched from the provider at boot by all instances.
   For other Certificate Providers that can autogenerate a CA when none is present (such as Tresor), atomicity and synchronization will be ensured during creation, ensuring all instances load the same CA.
 - Envoy Bootstrap Certificates (used by the proxies to authenticate against the control plane): these are created during injection webhook handling and inlined as part of the Proxy's bootstrap configuration. The configuration is stored as a kubernetes secret and mounted in the injected envoy pod as a volume, assuring idempotence for a single pod at any one time.
 

--- a/content/docs/guides/health_checks/control_plane_health_probes.md
+++ b/content/docs/guides/health_checks/control_plane_health_probes.md
@@ -41,8 +41,8 @@ Events:
   Type     Reason     Age               From               Message
   ----     ------     ----              ----               -------
   Normal   Scheduled  24s               default-scheduler  Successfully assigned osm-system/osm-controller-85fcb445b-fpv8l to osm-control-plane
-  Normal   Pulling    23s               kubelet            Pulling image "openservicemesh/osm-controller:v0.9.2"
-  Normal   Pulled     23s               kubelet            Successfully pulled image "openservicemesh/osm-controller:v0.9.2" in 562.2444ms
+  Normal   Pulling    23s               kubelet            Pulling image "openservicemesh/osm-controller:v0.8.0"
+  Normal   Pulled     23s               kubelet            Successfully pulled image "openservicemesh/osm-controller:v0.8.0" in 562.2444ms
   Normal   Created    1s (x2 over 23s)  kubelet            Created container osm-controller
   Normal   Started    1s (x2 over 23s)  kubelet            Started container osm-controller
   Warning  Unhealthy  1s (x3 over 21s)  kubelet            Liveness probe failed: HTTP probe failed with statuscode: 503
@@ -58,7 +58,7 @@ Events:
   ----     ------     ----              ----               -------
   Normal   Scheduled  36s               default-scheduler  Successfully assigned osm-system/osm-controller-5494bcffb6-tn5jv to osm-control-plane
   Normal   Pulling    36s               kubelet            Pulling image "openservicemesh/osm-controller:latest"
-  Normal   Pulled     35s               kubelet            Successfully pulled image "openservicemesh/osm-controller:v0.9.2" in 746.4323ms
+  Normal   Pulled     35s               kubelet            Successfully pulled image "openservicemesh/osm-controller:v0.8.0" in 746.4323ms
   Normal   Created    35s               kubelet            Created container osm-controller
   Normal   Started    35s               kubelet            Started container osm-controller
   Warning  Unhealthy  4s (x3 over 24s)  kubelet            Readiness probe failed: HTTP probe failed with statuscode: 503
@@ -102,7 +102,7 @@ If any health probes are consistently failing, perform the following steps to id
     ```console
     $ # Assuming OSM is installed in the osm-system namespace:
     $ kubectl get pod -n osm-system $(kubectl get pods -n osm-system -l app=osm-controller -o jsonpath='{.items[0].metadata.name}') -o jsonpath='{range .spec.containers[*]}{.image}{"\n"}{end}'
-    openservicemesh/osm-controller:v0.9.2
+    openservicemesh/osm-controller:v0.8.0
     envoyproxy/envoy-alpine:v1.17.2
     ```
 
@@ -112,7 +112,7 @@ If any health probes are consistently failing, perform the following steps to id
     ```console
     $ # Assuming OSM is installed in the osm-system namespace:
     $ kubectl get pod -n osm-system $(kubectl get pods -n osm-system -l app=osm-injector -o jsonpath='{.items[0].metadata.name}') -o jsonpath='{range .spec.containers[*]}{.image}{"\n"}{end}'
-    openservicemesh/osm-injector:v0.9.2
+    openservicemesh/osm-injector:v0.8.0
     envoyproxy/envoy-alpine:v1.17.2
     ```
 
@@ -124,8 +124,8 @@ If any health probes are consistently failing, perform the following steps to id
     $ osm mesh list
 
     MESH NAME   NAMESPACE      CONTROLLER PODS                  VERSION     SMI SUPPORTED
-    osm         osm-system     osm-controller-5494bcffb6-qpjdv  v0.9.2      HTTPRouteGroup:specs.smi-spec.io/v1alpha4,TCPRoute:specs.smi-spec.io/v1alpha4,TrafficSplit:split.smi-spec.io/v1alpha2,TrafficTarget:access.smi-spec.io/v1alpha3
-    osm2        osm-system-2   osm-controller-48fd3c810d-sornc  v0.9.2      HTTPRouteGroup:specs.smi-spec.io/v1alpha4,TCPRoute:specs.smi-spec.io/v1alpha4,TrafficSplit:split.smi-spec.io/v1alpha2,TrafficTarget:access.smi-spec.io/v1alpha3
+    osm         osm-system     osm-controller-5494bcffb6-qpjdv  v0.8.0      HTTPRouteGroup:specs.smi-spec.io/v1alpha4,TCPRoute:specs.smi-spec.io/v1alpha4,TrafficSplit:split.smi-spec.io/v1alpha2,TrafficTarget:access.smi-spec.io/v1alpha3
+    osm2        osm-system-2   osm-controller-48fd3c810d-sornc  v0.8.0      HTTPRouteGroup:specs.smi-spec.io/v1alpha4,TCPRoute:specs.smi-spec.io/v1alpha4,TrafficSplit:split.smi-spec.io/v1alpha2,TrafficTarget:access.smi-spec.io/v1alpha3
     ```
 
     Note how `osm-system` is present in the following list:

--- a/content/docs/guides/health_checks/health_probes.md
+++ b/content/docs/guides/health_checks/health_probes.md
@@ -331,13 +331,13 @@ Events:
   Type     Reason     Age              From               Message
   ----     ------     ----             ----               -------
   Normal   Scheduled  17s              default-scheduler  Successfully assigned bookstore/bookstore-v1-699c79b9dc-5g8zn to osm-control-plane
-  Normal   Pulled     16s              kubelet            Successfully pulled image "openservicemesh/init:v0.9.2" in 26.5835ms
+  Normal   Pulled     16s              kubelet            Successfully pulled image "openservicemesh/init:v0.8.0" in 26.5835ms
   Normal   Created    16s              kubelet            Created container osm-init
   Normal   Started    16s              kubelet            Started container osm-init
-  Normal   Pulling    16s              kubelet            Pulling image "openservicemesh/init:v0.9.2"
+  Normal   Pulling    16s              kubelet            Pulling image "openservicemesh/init:v0.8.0"
   Normal   Pulling    15s              kubelet            Pulling image "envoyproxy/envoy-alpine:v1.17.2"
-  Normal   Pulling    15s              kubelet            Pulling image "openservicemesh/bookstore:v0.9.2"
-  Normal   Pulled     15s              kubelet            Successfully pulled image "openservicemesh/bookstore:v0.9.2" in 319.9863ms
+  Normal   Pulling    15s              kubelet            Pulling image "openservicemesh/bookstore:v0.8.0"
+  Normal   Pulled     15s              kubelet            Successfully pulled image "openservicemesh/bookstore:v0.8.0" in 319.9863ms
   Normal   Started    15s              kubelet            Started container bookstore-v1
   Normal   Created    15s              kubelet            Created container bookstore-v1
   Normal   Pulled     14s              kubelet            Successfully pulled image "envoyproxy/envoy-alpine:v1.17.2" in 755.2666ms
@@ -355,19 +355,19 @@ Events:
   Type     Reason     Age                From               Message
   ----     ------     ----               ----               -------
   Normal   Scheduled  59s                default-scheduler  Successfully assigned bookstore/bookstore-v1-746977967c-jqjt4 to osm-control-plane
-  Normal   Pulling    58s                kubelet            Pulling image "openservicemesh/init:v0.9.2"
+  Normal   Pulling    58s                kubelet            Pulling image "openservicemesh/init:v0.8.0"
   Normal   Created    58s                kubelet            Created container osm-init
   Normal   Started    58s                kubelet            Started container osm-init
-  Normal   Pulled     58s                kubelet            Successfully pulled image "openservicemesh/init:v0.9.2" in 23.415ms
+  Normal   Pulled     58s                kubelet            Successfully pulled image "openservicemesh/init:v0.8.0" in 23.415ms
   Normal   Pulled     57s                kubelet            Successfully pulled image "envoyproxy/envoy-alpine:v1.17.2" in 678.1391ms
-  Normal   Pulled     57s                kubelet            Successfully pulled image "openservicemesh/bookstore:v0.9.2" in 230.3681ms
+  Normal   Pulled     57s                kubelet            Successfully pulled image "openservicemesh/bookstore:v0.8.0" in 230.3681ms
   Normal   Created    57s                kubelet            Created container envoy
   Normal   Pulling    57s                kubelet            Pulling image "envoyproxy/envoy-alpine:v1.17.2"
   Normal   Started    56s                kubelet            Started container envoy
-  Normal   Pulled     44s                kubelet            Successfully pulled image "openservicemesh/bookstore:v0.9.2" in 20.6731ms
+  Normal   Pulled     44s                kubelet            Successfully pulled image "openservicemesh/bookstore:v0.8.0" in 20.6731ms
   Normal   Created    44s (x2 over 57s)  kubelet            Created container bookstore-v1
   Normal   Started    43s (x2 over 57s)  kubelet            Started container bookstore-v1
-  Normal   Pulling    32s (x3 over 58s)  kubelet            Pulling image "openservicemesh/bookstore:v0.9.2"
+  Normal   Pulling    32s (x3 over 58s)  kubelet            Pulling image "openservicemesh/bookstore:v0.8.0"
   Warning  Unhealthy  32s (x6 over 50s)  kubelet            Liveness probe failed: HTTP probe failed with statuscode: 503
   Normal   Killing    32s (x2 over 44s)  kubelet            Container bookstore-v1 failed liveness probe, will be restarted
 ```
@@ -380,13 +380,13 @@ Events:
   Type     Reason     Age               From               Message
   ----     ------     ----              ----               -------
   Normal   Scheduled  32s               default-scheduler  Successfully assigned bookstore/bookstore-v1-5848999cb6-hp6qg to osm-control-plane
-  Normal   Pulling    31s               kubelet            Pulling image "openservicemesh/init:v0.9.2"
-  Normal   Pulled     31s               kubelet            Successfully pulled image "openservicemesh/init:v0.9.2" in 19.8726ms
+  Normal   Pulling    31s               kubelet            Pulling image "openservicemesh/init:v0.8.0"
+  Normal   Pulled     31s               kubelet            Successfully pulled image "openservicemesh/init:v0.8.0" in 19.8726ms
   Normal   Created    31s               kubelet            Created container osm-init
   Normal   Started    31s               kubelet            Started container osm-init
   Normal   Created    30s               kubelet            Created container bookstore-v1
-  Normal   Pulled     30s               kubelet            Successfully pulled image "openservicemesh/bookstore:v0.9.2" in 314.3628ms
-  Normal   Pulling    30s               kubelet            Pulling image "openservicemesh/bookstore:v0.9.2"
+  Normal   Pulled     30s               kubelet            Successfully pulled image "openservicemesh/bookstore:v0.8.0" in 314.3628ms
+  Normal   Pulling    30s               kubelet            Pulling image "openservicemesh/bookstore:v0.8.0"
   Normal   Started    30s               kubelet            Started container bookstore-v1
   Normal   Pulling    30s               kubelet            Pulling image "envoyproxy/envoy-alpine:v1.17.2"
   Normal   Pulled     29s               kubelet            Successfully pulled image "envoyproxy/envoy-alpine:v1.17.2" in 739.3931ms

--- a/content/docs/guides/install.md
+++ b/content/docs/guides/install.md
@@ -34,13 +34,13 @@ _Note: Installing OSM via the CLI enforces deploying only one mesh in the cluste
 
 ### Using the Helm CLI
 
-The [OSM chart](https://github.com/openservicemesh/osm/tree/release-v0.9/charts/osm) can be installed directly via the [Helm CLI](https://helm.sh/docs/intro/install/).
+The [OSM chart](https://github.com/openservicemesh/osm/tree/{{< param osm_branch >}}/charts/osm) can be installed directly via the [Helm CLI](https://helm.sh/docs/intro/install/).
 
 #### Editing the Values File
 
 You can configure the OSM installation by overriding the values file.
 
-1. Create a copy of the [values file](https://github.com/openservicemesh/osm/blob/release-v0.9/charts/osm/values.yaml) (make sure to use the version for the chart you wish to install).
+1. Create a copy of the [values file](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/charts/osm/values.yaml) (make sure to use the version for the chart you wish to install).
 1. Change any values you wish to customize. You can omit all other values.
 
    - To see which values correspond to the MeshConfig settings, see the [OSM MeshConfig documentation](/docs/guides/mesh_config)
@@ -53,7 +53,7 @@ You can configure the OSM installation by overriding the values file.
 
 #### Helm install
 
-Then run the following `helm install` command. The chart version can be found in the Helm chart you wish to install [here](https://github.com/openservicemesh/osm/blob/release-v0.9/charts/osm/Chart.yaml#L17).
+Then run the following `helm install` command. The chart version can be found in the Helm chart you wish to install [here](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/charts/osm/Chart.yaml#L17).
 
 ```console
 $ helm install <mesh name> osm --repo https://openservicemesh.github.io/osm --version <chart version> --namespace <osm namespace> --values override.yaml

--- a/content/docs/guides/mesh_config.md
+++ b/content/docs/guides/mesh_config.md
@@ -9,7 +9,7 @@ weight: 7
 # OSM MeshConfig
 OSM deploys a MeshConfig resource `osm-mesh-config` as a part of its control plane (in the same namespace as that of the osm-controller pod) which can be updated by the mesh owner/operator at any time. The purpose of this MeshConfig is to provide the mesh owner/operator the ability to update some of the mesh configurations based on their needs.
 
-At the time of install, the OSM MeshConfig is deployed from a preset MeshConfig (`preset-mesh-config`) which can be found under [charts/osm/templates](https://github.com/openservicemesh/osm/blob/release-v0.9/charts/osm/templates/preset-mesh-config.yaml).
+At the time of install, the OSM MeshConfig is deployed from a preset MeshConfig (`preset-mesh-config`) which can be found under [charts/osm/templates](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/charts/osm/templates/preset-mesh-config.yaml).
 To view your `osm-mesh-config` in CLI use the `kubectl get` command.
 ```bash
 # Replace osm-system with osm-controller's namespace if using a non-default namespace
@@ -27,7 +27,7 @@ kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"
 ```
 Refer to the [Config API reference](/docs/apidocs/config/v1alpha1) for more information.
 
-If an incorrect value is used, validations on the [MeshConfig CRD](https://github.com/openservicemesh/osm/blob/release-v0.9/charts/osm/crds/meshconfig.yaml) will prevent the change with an error message explaining why the value is invalid.
+If an incorrect value is used, validations on the [MeshConfig CRD](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/charts/osm/crds/meshconfig.yaml) will prevent the change with an error message explaining why the value is invalid.
 For example, the below command shows what happens if we patch `enableEgress` to a non-boolean value.
 ```bash
 kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"traffic":{"enableEgress":"no"}}}'  --type=merge
@@ -53,5 +53,5 @@ The MeshConfig "osm-mesh-config" is invalid: spec.traffic.enableEgress: Invalid 
 | spec.sidecar.logLevel | string | `"error"` | `kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"sidecar":{"logLevel":"error"}}}'  --type=merge` |
 | spec.sidecar.maxDataPlaneConnections | int | `0` | `kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"sidecar":{"maxDataPlaneConnections":"error"}}}'  --type=merge` |
 | spec.sidecar.envoyImage | string | `"envoyproxy/envoy-alpine:v1.17.2"` | `kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"sidecar":{"envoyImage":"envoyproxy/envoy-alpine:v1.17.2"}}}'  --type=merge` |
-| spec.sidecar.initContainerImage | string | `"openservicemesh/init:v0.9.2"` | `kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"sidecar":{"initContainerImage":"openservicemesh/init:v0.9.2"}}}' --type=merge` |
+| spec.sidecar.initContainerImage | string | `"openservicemesh/init:{{< param osm_version >}}"` | `kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"sidecar":{"initContainerImage":"openservicemesh/init:{{< param osm_version >}}"}}}' --type=merge` |
 | spec.sidecar.configResyncInterval | string | `"0s"` | `kubectl patch meshconfig osm-mesh-config -n osm-system -p '{"spec":{"sidecar":{"configResyncInterval":"30s"}}}'  --type=merge` |

--- a/content/docs/guides/observability/logs.md
+++ b/content/docs/guides/observability/logs.md
@@ -47,7 +47,7 @@ When enabled, Fluent Bit can collect these logs, process them and send them to a
 OSM provides log forwarding by optionally deploying a Fluent Bit sidecar to the OSM controller using the `--set=OpenServiceMesh.enableFluentbit=true` flag during installation. The user can then define where OSM logs should be forwarded using any of the available [Fluent Bit output plugins](https://docs.fluentbit.io/manual/pipeline/outputs).
 
 ### Configuring Log Forwarding with Fluent Bit
-By default, the Fluent Bit sidecar is configured to simply send logs to the Fluent Bit container's stdout. If you have installed OSM with Fluent Bit enabled, you may access these logs using `kubectl logs -n osm-system <osm-controller-name> -c fluentbit-logger`. This command will also help you find how your logs are formatted in case you need to change your parsers and filters. 
+By default, the Fluent Bit sidecar is configured to simply send logs to the Fluent Bit container's stdout. If you have installed OSM with Fluent Bit enabled, you may access these logs using `kubectl logs -n osm-system <osm-controller-name> -c fluentbit-logger`. This command will also help you find how your logs are formatted in case you need to change your parsers and filters.
 
 To quickly bring up Fluent Bit with default values, use:
 ```console
@@ -59,7 +59,7 @@ Once you have tried out this basic setup, we recommend configuring log forwardin
 
 To customize log forwarding to your output, follow these steps and then reinstall OSM with Fluent Bit enabled.
 
-1. Find the output plugin you would like to forward your logs to in [Fluent Bit documentation](https://docs.fluentbit.io/manual/pipeline/outputs). Replace the `[OUTPUT]` section in [`fluentbit-configmap.yaml`](https://github.com/openservicemesh/osm/blob/release-v0.9/charts/osm/templates/fluentbit-configmap.yaml) with appropriate values.
+1. Find the output plugin you would like to forward your logs to in [Fluent Bit documentation](https://docs.fluentbit.io/manual/pipeline/outputs). Replace the `[OUTPUT]` section in [`fluentbit-configmap.yaml`](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/charts/osm/templates/fluentbit-configmap.yaml) with appropriate values.
 
 1. The default configuration uses CRI log format parsing. If you are using a kubernetes distribution that causes your logs to be formatted differently, you may need to add a new parser to the `[PARSER]` section and change the `parser` name in the `[INPUT]` section to one of the parsers defined [here](https://github.com/fluent/fluent-bit/blob/master/conf/parsers.conf).
 
@@ -131,4 +131,4 @@ Alternatively, you may change the values in the Helm chart by updating the follo
     ```console
     osm install --set=OpenServiceMesh.enableFluentbit=true
     ```
-> NOTE: Ensure that the [Fluent Bit image tag](https://github.com/openservicemesh/osm/blob/release-v0.9/charts/osm/values.yaml) is `1.6.4` or greater as it is required for this feature.
+> NOTE: Ensure that the [Fluent Bit image tag](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/charts/osm/values.yaml) is `1.6.4` or greater as it is required for this feature.

--- a/content/docs/guides/observability/metrics.md
+++ b/content/docs/guides/observability/metrics.md
@@ -308,7 +308,7 @@ OSM provides some pre-cooked Grafana dashboards to display and track services re
      ![image](https://user-images.githubusercontent.com/64559656/138173158-5baad409-b194-49ed-b4cc-3a939e84f800.png)
 
 [1]: https://prometheus.io/docs/introduction/overview/
-[2]: https://github.com/openservicemesh/osm/blob/release-v0.9/demo/README.md
+[2]: https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/demo/README.md
 [3]: https://grafana.com/docs/grafana/latest/getting-started/#what-is-grafana
 [4]: http://localhost:3000
 [5]: http://localhost:7070

--- a/content/docs/guides/observability/tracing.md
+++ b/content/docs/guides/observability/tracing.md
@@ -85,7 +85,7 @@ Navigate to `http://localhost:16686/` in a web browser to view the UI.
 ## Example of Tracing with Jaeger
 This section walks through the process of creating a simple Jaeger instance and enabling tracing with Jaeger in OSM.
 
-1. Run the [OSM Demo](https://github.com/openservicemesh/osm/blob/release-v0.9/demo/README.md) with Jaeger deployed. You have two options:
+1. Run the [OSM Demo](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/demo/README.md) with Jaeger deployed. You have two options:
     - For automatic provisioning of Jaeger, simply set `DEPLOY_JAEGER` in your `.env` file to true
     - For bring-your-own, you can deploy the sample instance [provided by Jaeger](https://www.jaegertracing.io/docs/1.22/getting-started/#all-in-one) using the commands below. If you wish to bring up Jaeger in a different namespace, make sure to update it below.
 

--- a/content/docs/guides/traffic_management/iptables_redirection.md
+++ b/content/docs/guides/traffic_management/iptables_redirection.md
@@ -147,7 +147,7 @@ The following snippet from the demo `curl` client's init container spec shows th
 Init Containers:
   osm-init:
     Container ID:  containerd://80f86af7bc64b7a70f7f2bf64242d735d857559a79cd97e206513368130902f1
-    Image:         openservicemesh/init:v0.9.2
+    Image:         openservicemesh/init:{{< param osm_version >}}
     Image ID:      docker.io/openservicemesh/init@sha256:eb1f6ab02aeaaba8f58aaa29406b1653d7a3983958ea040c2af8845136ed786c
     Port:          <none>
     Host Port:     <none>

--- a/content/docs/guides/troubleshooting/install.md
+++ b/content/docs/guides/troubleshooting/install.md
@@ -19,7 +19,7 @@ As a result, one may see this error during a subsequent install of a new mesh wi
 Error: rendered manifests contain a resource that already exists. Unable to continue with install: ClusterRole "<mesh-name>" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "<new-namespace>": current value is "<old-namespace>"
 ```
 
-In the case of this error, use the [cleanup script](https://github.com/openservicemesh/osm/blob/release-v0.9/scripts/cleanup/osm-cleanup.sh) located in the osm repository to delete any remaining resources.
+In the case of this error, use the [cleanup script](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/scripts/cleanup/osm-cleanup.sh) located in the osm repository to delete any remaining resources.
 
 To run the script, create a `.env` environment variable file to set the values specified at the top of the script. These values should match the values used to deploy the mesh.
 
@@ -33,7 +33,7 @@ Then, try installing OSM again on the cluster.
 
 # OSM Mesh Uninstall Troubleshooting Guide
 
-If for any reason, `osm uninstall` is unsuccessful, run the [cleanup script](https://github.com/openservicemesh/osm/blob/release-v0.8/scripts/cleanup/osm-cleanup.sh) which will delete any OSM related resources.
+If for any reason, `osm uninstall` is unsuccessful, run the [cleanup script](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/scripts/cleanup/osm-cleanup.sh) which will delete any OSM related resources.
 
 To run the script, create a `.env` environment variable file to set the values specified at the top of the script. These values should match the values used to deploy the mesh.
 

--- a/content/docs/guides/upgrade.md
+++ b/content/docs/guides/upgrade.md
@@ -72,7 +72,7 @@ $ osm mesh upgrade
 OSM successfully upgraded mesh osm
 ```
 
-This command will upgrade the mesh with the default mesh name in the default OSM namespace. Values from the previous release will carry over to the new release except for `OpenServiceMesh.image.registry` and `OpenServiceMesh.image.tag` which are overridden by default. For example, if OSM v0.7.0 is installed, `osm mesh upgrade` for v0.9.2 of the CLI will update the control plane images to v0.9.2 by default.
+This command will upgrade the mesh with the default mesh name in the default OSM namespace. Values from the previous release will carry over to the new release except for `OpenServiceMesh.image.registry` and `OpenServiceMesh.image.tag` which are overridden by default. For example, if OSM v0.7.0 is installed, `osm mesh upgrade` for {{< param osm_version >}} of the CLI will update the control plane images to {{< param osm_version >}} by default.
 
 See `osm mesh upgrade --help` for more details
 
@@ -81,12 +81,12 @@ See `osm mesh upgrade --help` for more details
 #### Pre-requisites
 
 - Kubernetes cluster with the OSM control plane installed
-- The [helm 3 CLI](https://helm.sh/docs/intro/install/) 
+- The [helm 3 CLI](https://helm.sh/docs/intro/install/)
 
 #### OSM Configuration
 When upgrading, any custom settings used to install or run OSM may be reverted to the default, this only includes any metrics deployments. Please ensure that you carefully follow the guide to prevent these values from being overwritten.
 
-To preserve any changes you've made to the OSM configuration, use the `helm --values` flag. Create a copy of the [values file](https://github.com/openservicemesh/osm/blob/release-v0.9/charts/osm/values.yaml) (make sure to use the version for the upgraded chart) and change any values you wish to customize. You can omit all other values.
+To preserve any changes you've made to the OSM configuration, use the `helm --values` flag. Create a copy of the [values file](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/charts/osm/values.yaml) (make sure to use the version for the upgraded chart) and change any values you wish to customize. You can omit all other values.
 
 **Note: Any configuration changes that go into the MeshConfig will not be applied during upgrade and the values will remain as is prior to the upgrade. If you wish to update any value in the MeshConfig you can do so by patching the resource after an upgrade.
 
@@ -107,14 +107,14 @@ Run `helm upgrade --help` for more options.
 
 ### Envoy
 
-The envoy version can be updated by changing the value of the `envoyImage` variable in the osm-mesh-config. When doing so, it is recommended to specify the image digest associated with that envoy version to avoid being vulnerable to supply chain attacks. For instance, to update the [envoy-alpine image](https://hub.docker.com/r/envoyproxy/envoy-alpine/tags) to v1.19.1, the following command should be run: 
+The envoy version can be updated by changing the value of the `envoyImage` variable in the osm-mesh-config. When doing so, it is recommended to specify the image digest associated with that envoy version to avoid being vulnerable to supply chain attacks. For instance, to update the [envoy-alpine image](https://hub.docker.com/r/envoyproxy/envoy-alpine/tags) to v1.19.1, the following command should be run:
 
 ```bash
 export osm_namespace=<osm-namespace> # Replace <osm-namespace> with the namespace where OSM is installed
 kubectl patch meshconfig osm-mesh-config -n $osm_namespace -p '{"spec":{"sidecar":{"envoyImage":"envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd"}}}' --type=merge
 ```
 
-After the MeshConfig resource has been updated, all the pods and deployments that are part of the mesh must be restarted so that the newer version of Envoy sidecar can be injected onto the pods as a part of the automatic sidecar injection that OSM performs. This can be done with the `kubectl rollout restart deploy` command. 
+After the MeshConfig resource has been updated, all the pods and deployments that are part of the mesh must be restarted so that the newer version of Envoy sidecar can be injected onto the pods as a part of the automatic sidecar injection that OSM performs. This can be done with the `kubectl rollout restart deploy` command.
 
 ### Prometheus, Grafana, and Jaeger
 
@@ -125,7 +125,7 @@ export osm_namespace=<osm-namespace> # Replace <osm-namespace> with the namespac
 kubectl set image deployment/osm-prometheus -n $osm_namespace prometheus="prom/prometheus:v2.19.1"
 ```
 
-To update to Grafana 8.1.0, the command would look like: 
+To update to Grafana 8.1.0, the command would look like:
 
 ```bash
 kubectl set image deployment/osm-grafana -n $osm_namespace grafana="grafana/grafana:8.1.0"


### PR DESCRIPTION
Parameterizes the osm branch (ex: release-v0.11), osm version
(ex: v0.11.0), and the envoy version (ex: v1.17.2) to improve the
process of creating a release specific site.

TODO:
- remove anchors to specific lines in main
- update the release guide for docs to reflect this change

Signed-off-by: jaellio <jaellio@microsoft.com>