### PR TITLE
Fix docs site redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,6 @@
   HUGO_ENV = "production"
 
 [[redirects]]
-  from = "https://docs.openservicemesh.io/"
-  to = "https://release-v0-11.docs.openservicemesh.io/"
+  from = "https://docs.openservicemesh.io/*"
+  to = "https://release-v0-11.docs.openservicemesh.io/:splat"
   force = true


### PR DESCRIPTION
Adds an asterisk to the redirected path,
https://docs.openservicemesh.io/. The splat will match anything
that follows the asterisk.

Signed-off-by: jaellio <jaellio@microsoft.com>