### PR TITLE
update docs for traffic split in permissive mode

### DIFF
--- a/content/docs/getting_started/setup_osm.md
+++ b/content/docs/getting_started/setup_osm.md
@@ -57,7 +57,7 @@ This command enables
 [Jaeger](https://github.com/jaegertracing/jaeger) integrations.
 The `osm.enablePermissiveTrafficPolicy` chart parameter in the `values.yaml` file instructs OSM to ignore any policies and
 let traffic flow freely between the pods. With Permissive Traffic Policy mode enabled, new pods
-will be injected with Envoy, but traffic will flow through the proxy and will not be blocked.
+will be injected with Envoy, but traffic will flow through the proxy and will not be blocked by access control policies.
 
 > Note: Permissive Traffic Policy mode is an important feature for brownfield deployments, where it may take some time to craft SMI policies. While operators design the SMI policies, existing services will continue to operate as they have been before OSM was installed.
 

--- a/content/docs/getting_started/traffic_policies.md
+++ b/content/docs/getting_started/traffic_policies.md
@@ -9,7 +9,7 @@ weight: 3
 
 ## Traffic Policy Modes
 
-Once the applications are up and running, they can interact with each other using [permissive traffic policy mode](#permissive-traffic-policy-mode) or [SMI traffic policy mode](#smi-traffic-policy-mode). In permissive traffic policy mode, traffic between application services is automatically configured by `osm-controller`, and SMI policies are not enforced. In the SMI policy mode, all traffic is denied by default unless explicitly allowed using a combination of SMI access and routing policies.
+Once the applications are up and running, they can interact with each other using [permissive traffic policy mode](#permissive-traffic-policy-mode) or [SMI traffic policy mode](#smi-traffic-policy-mode). In permissive traffic policy mode, traffic between application services is automatically configured by `osm-controller`, and access control policies defined by SMI Traffic Targets are not enforced. In the SMI policy mode, all traffic is denied by default unless explicitly allowed using a combination of SMI access and routing policies.
 
 ### Traffic Encryption
 

--- a/content/docs/guides/traffic_management/permissive_mode.md
+++ b/content/docs/guides/traffic_management/permissive_mode.md
@@ -6,11 +6,11 @@ weight: 2
 ---
 
 # Permissive Traffic Policy Mode
-Permissive traffic policy mode in OSM is a mode where [SMI][1] traffic policy enforcement is bypassed. In this mode, OSM automatically discovers services that are a part of the service mesh and programs traffic policy rules on each Envoy proxy sidecar to be able to communicate with these services.
+Permissive traffic policy mode in OSM is a mode where [SMI][1] traffic access policy enforcement is bypassed. In this mode, OSM automatically discovers services that are a part of the service mesh and programs traffic policy rules on each Envoy proxy sidecar to be able to communicate with these services.
 
 ## When to use permissive traffic policy mode
-Since permissive traffic policy mode bypasses [SMI][1] traffic policy enforcement, it is suitable for use when connectivity between applications within the service mesh should flow as before the applications were enrolled into the mesh. This mode is suitable in environments
-where explicitly defining traffic policies for connectivity between applications is not feasible.
+Since permissive traffic policy mode bypasses [SMI][1] traffic access policy enforcement, it is suitable for use when connectivity between applications within the service mesh should flow as before the applications were enrolled into the mesh. This mode is suitable in environments
+where explicitly defining traffic access policies for connectivity between applications is not feasible.
 
 A common use case to enable permissive traffic policy mode is to support gradual onboarding of applications into the mesh without breaking application connectivity. Traffic routing between application services is automatically set up by OSM controller through service discovery. Wildcard traffic policies are set up on each Envoy proxy sidecar to allow traffic flow to services within the mesh.
 

--- a/content/docs/guides/troubleshooting/traffic_management/permissive_traffic_policy_mode.md
+++ b/content/docs/guides/troubleshooting/traffic_management/permissive_traffic_policy_mode.md
@@ -6,7 +6,7 @@ type: docs
 
 ## When permissive traffic policy mode is not working as expected
 
-### 1. Confirm Permissive traffic policy mode is enabled
+### 1. Confirm permissive traffic policy mode is enabled
 
 Confirm permissive traffic policy mode is enabled by verifying the value for the `enablePermissiveTrafficPolicyMode` key in the `osm-mesh-config` custom resource. `osm-mesh-config` MeshConfig resides in the namespace OSM control plane namespace (`osm-system` by default).
 


### PR DESCRIPTION
Subtle language updates to indicate that permissive mode is specific to access control policies/traffic targets, not all SMI policies

ref: https://github.com/openservicemesh/osm/issues/2527 

Signed-off-by: Sanya Kochhar <kochhars@microsoft.com>