### PR TITLE
Simplify the NGINX Ingress guide

### DIFF
--- a/content/docs/demos/ingress_k8s_nginx.md
+++ b/content/docs/demos/ingress_k8s_nginx.md
@@ -153,7 +153,7 @@ kubectl patch MeshConfig \
 ```
 
 As a result of these changes to `osm-mesh-config`, OSM Controller will create a new secret with an mTLS certificate in it.
-Look for the newly created mTLS certificate: `kubectl get secrets -n osm-system osm-ingress-mtls`
+Look for the newly created mTLS certificate: `kubectl get secrets -n ingress-nginx osm-ingress-mtls`
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
This PR aims to simplify the doc guiding the OSM user through installation of NGINX Ingress Controller and integrating it with Open Service Mesh.

Goals and principles:
- use short, succinct sentences
- remove unnecessary language
- bring all YAML in the context of the page so it is easy to see without navigating away from the page
- remove bash variables and scripts (use predefined namespaces etc)