### PR TITLE
Temporarily remove references to Grafana.com

### DIFF
--- a/content/docs/demos/prometheus_grafana.md
+++ b/content/docs/demos/prometheus_grafana.md
@@ -316,25 +316,15 @@ Saving and testing at this stage should already be enough, and Grafana should te
 <center><i>"Save and test" should greet you with that green banner</i></center><br>
 
 ## Importing OSM Dashboards
-OSM Dashboards are available both through:
-- [our repository](https://github.com/openservicemesh/osm/tree/{{< param osm_branch >}}/charts/osm/grafana), and are importable as json blobs through the web admin portal
-- or [online at Grafana.com](https://grafana.com/grafana/dashboards/14145)
+OSM Dashboards are available through [our repository](https://github.com/openservicemesh/osm/tree/{{< param osm_branch >}}/charts/osm/grafana/dashboards), which can be imported as json blobs on the web admin portal.
 
-To import a dashboard, look for the `+` sign on the left menu and select `import`.
-You can directly import dashboard by their ID on `Grafana.com`. For example, our `OSM Mesh Details` dashboard uses id `14145`, you can use the ID directly on the form and click `load`:
+To import a dashboard, look for the `+` sign on the left menu and select `Import`.
+Once the json file has been loaded, configure Prometheus as the data source.
 
-<p align="center">
-  <img src="/docs/images/byo_guide/grafana_import.png" width="50%">
-</p>
-<center><i>Should show our dashboard in Grafana.com</i></center><br>
-
-Last step is to configure Prometheus source for the imported dashboard (bottom of previous screenshot).
+![importGrafana](https://user-images.githubusercontent.com/64559656/140592184-2d781ae1-dae6-4d5e-922c-c536298968f7.png)
 
 As soon as you click import, it will bring you automatically to your imported dashboard.
 
-<p align="center">
-  <img src="/docs/images/byo_guide/meshdetails.png" width="80%"/>
-</p>
 <center><i>Ready to go. Happy monitoring!</i></center><br>
 
 

--- a/content/docs/guides/observability/metrics.md
+++ b/content/docs/guides/observability/metrics.md
@@ -128,10 +128,7 @@ The following section assumes a Prometheus instance has already been configured 
 
 ##### Importing OSM Dashboards
 
-The OSM dashboards (if desired) can be imported through several mechanisms to the external Grafana instance.
-OSM Dashboards are available both through:
-- [OSM repository](https://github.com/openservicemesh/osm/tree/release-v0.9/charts/osm/grafana), and are importable as json blobs through the web admin portal
-- or [online at Grafana.com](https://grafana.com/grafana/dashboards/14145).
+OSM Dashboards are available through [our repository](https://github.com/openservicemesh/osm/tree/{{< param osm_branch >}}/charts/osm/grafana/dashboards), which can be imported as json blobs on the web admin portal.
 
 Detailed instructions for importing OSM dashboards can be found in the [Prometheus and Grafana](/docs/demos/prometheus_grafana) demo. Refer to [OSM Grafana dashboard](#osm-grafana-dashboards) for an overview of the pre-configured dashboards.
 


### PR DESCRIPTION
Creating PR for @jaellio

To avoid blocking v1 on uploading the Grafana dashboards to the
Grafana dashboard library, remove option from docs to get OSM
dashboards from the library. The dashboard JSON is still available
in the OSM repo. Instructions can be added back once the
dashboards for v1 have been added the OSM Grafana account.