### PR TITLE
docs(content/docs/guides/*): update left nav order and titles

### DIFF
--- a/content/docs/guides/_index.md
+++ b/content/docs/guides/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Guides"
+title: "How-to Guides"
 description: "Learn how to use Open Service Mesh (OSM)"
 type: docs
 weight: 3

--- a/content/docs/guides/app_onboarding/_index.md
+++ b/content/docs/guides/app_onboarding/_index.md
@@ -2,7 +2,7 @@
 title: "Application onboarding"
 description: "Onboard Services"
 type: docs
-weight: 6
+weight: 5
 ---
 
 # Onboard Services

--- a/content/docs/guides/cli.md
+++ b/content/docs/guides/cli.md
@@ -1,5 +1,5 @@
 ---
-title: "OSM CLI"
+title: "Install the OSM CLI"
 description: "This section describes installing and using the `osm` CLI."
 type: docs
 weight: 1

--- a/content/docs/guides/install.md
+++ b/content/docs/guides/install.md
@@ -1,5 +1,5 @@
 ---
-title: "Installation"
+title: "Install the OSM Control Plane"
 description: "This section describes how to install/uninstall Open Service Mesh (OSM) on a Kubernetes cluster"
 type: docs
 weight: 2

--- a/content/docs/guides/osm_resource_limits.md
+++ b/content/docs/guides/osm_resource_limits.md
@@ -2,7 +2,7 @@
 title: "OSM Resource Requests and Limits"
 description: "Resource requests and limits for OSM pods and deployments"
 type: docs
-weight: 2
+weight: 5
 ---
 
 | Key | Type | Default | Description |

--- a/content/docs/guides/smi.md
+++ b/content/docs/guides/smi.md
@@ -2,7 +2,7 @@
 title: Service Mesh Interface (SMI) Support
 description: "SMI implementation in OSM"
 type: docs
-weight: 4
+weight: 5
 ---
 
 ## Overview

--- a/content/docs/guides/uninstall.md
+++ b/content/docs/guides/uninstall.md
@@ -1,5 +1,5 @@
 ---
-title: "Uninstall"
+title: "Uninstall the OSM Control Plane"
 description: "Uninstall"
 type: docs
 weight: 4

--- a/content/docs/guides/upgrade.md
+++ b/content/docs/guides/upgrade.md
@@ -1,5 +1,5 @@
 ---
-title: "Upgrade Guide"
+title: "Upgrade the OSM Control Plane"
 description: "Upgrade Guide"
 aliases: ["/docs/upgrade_guide","/docs/troubleshooting/cli/mesh_upgrade"]
 type: docs

--- a/themes/dosmy/layouts/partials/sidebar-tree.html
+++ b/themes/dosmy/layouts/partials/sidebar-tree.html
@@ -39,6 +39,7 @@
       {{ if not $show }} collapsed{{ end }}{{ if $active}} active{{ end }}
     ">{{ $s.LinkTitle }}</a>
   </li>
+  {{ if or (or $active $show) (eq $p.URL "/")}}
   <ul class="td-sidebar-docs-menu">
     <li class="collapse {{ if $show }}show{{ end }}" id="{{ $sid }}">
       {{ $pages := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true }}
@@ -46,13 +47,17 @@
       {{ range $pages }}
       {{ if .IsPage }}
       {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
-      {{ $active := eq . $p }}
-      <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+      {{ $pageActive := eq . $p }}
+      <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $pageActive }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+      {{ else if (eq $p.URL "/") }}
+      {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
+      <a class="td-sidebar-link td-sidebar-link__page" id="{{ $mid }}" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
       {{ else }}
       {{ template "section-tree-nav-section" (dict "page" $p "section" .) }}
       {{ end }}
       {{ end }}
     </li>
   </ul>
+  {{ end }}
 </ul>
 {{ end }}


### PR DESCRIPTION
Change order and wording of doc titles in left nav for better
findability

docs(themes/dosmy/layouts/partials/sidebar-tree.html): change display
logic of left nav

Updated display logic to expand tree for active items only. This
allows for a cleaner display and makes it easier to navigate.

Signed-off-by: Zach Rhoads <zachary.rhoads@microsoft.com>