### PR TITLE
docs: update api reference and add examples to ingress guide

### DIFF
--- a/content/docs/api_reference/config/v1alpha1.md
+++ b/content/docs/api_reference/config/v1alpha1.md
@@ -70,6 +70,68 @@ IngressGatewayCertSpec
 </tr>
 </tbody>
 </table>
+<h3 id="config.openservicemesh.io/v1alpha1.ClusterSpec">ClusterSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#config.openservicemesh.io/v1alpha1.MultiClusterServiceSpec">MultiClusterServiceSpec</a>)
+</p>
+<p>
+<p>ClusterSpec is the type used to represent a remote cluster in multicluster scenarios.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>address</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Address defines the remote IP address of the gateway</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name defines the name of the remote cluster.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>weight</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<p>Weight defines the load balancing weight of the remote cluster</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priority</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<p>Priority defines the priority of the remote cluster in locality based load balancing</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="config.openservicemesh.io/v1alpha1.ExternalAuthzSpec">ExternalAuthzSpec
 </h3>
 <p>
@@ -229,17 +291,6 @@ bool
 </tr>
 <tr>
 <td>
-<code>enableValidatingWebhook</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>EnableValidatingWebhook defines if the OSM controller will create a validating webhook handler.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>enableIngressBackendPolicy</code><br/>
 <em>
 bool
@@ -260,6 +311,17 @@ bool
 <td>
 <p>EnableEnvoyActiveHealthChecks defines if OSM will Envoy active health
 checks between services allowed to communicate.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>enableRetryPolicy</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>EnableRetryPolicy defines if retry policy is enabled.</p>
 </td>
 </tr>
 </tbody>
@@ -514,6 +576,147 @@ FeatureFlags
 </tr>
 </tbody>
 </table>
+<h3 id="config.openservicemesh.io/v1alpha1.MultiClusterService">MultiClusterService
+</h3>
+<p>
+<p>MultiClusterService is the type used to represent the multicluster configuration.
+MultiClusterService name needs to match the name of the service backing the pods in each cluster.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-20.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Object&rsquo;s metadata.</p>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha1.MultiClusterServiceSpec">
+MultiClusterServiceSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec is the MultiClusterService specification.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>clusters</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha1.ClusterSpec">
+[]ClusterSpec
+</a>
+</em>
+</td>
+<td>
+<p>ClusterSpec defines the configuration of other clusters</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccount</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ServiceAccount represents the service account of the multicluster service.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha1.PortSpec">
+[]PortSpec
+</a>
+</em>
+</td>
+<td>
+<p>Ports is the list of ports exported by this service.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="config.openservicemesh.io/v1alpha1.MultiClusterServiceSpec">MultiClusterServiceSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#config.openservicemesh.io/v1alpha1.MultiClusterService">MultiClusterService</a>)
+</p>
+<p>
+<p>MultiClusterServiceSpec is the type used to represent the multicluster service specification.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>clusters</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha1.ClusterSpec">
+[]ClusterSpec
+</a>
+</em>
+</td>
+<td>
+<p>ClusterSpec defines the configuration of other clusters</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccount</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ServiceAccount represents the service account of the multicluster service.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha1.PortSpec">
+[]PortSpec
+</a>
+</em>
+</td>
+<td>
+<p>Ports is the list of ports exported by this service.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="config.openservicemesh.io/v1alpha1.ObservabilitySpec">ObservabilitySpec
 </h3>
 <p>
@@ -567,6 +770,46 @@ TracingSpec
 </tr>
 </tbody>
 </table>
+<h3 id="config.openservicemesh.io/v1alpha1.PortSpec">PortSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#config.openservicemesh.io/v1alpha1.MultiClusterServiceSpec">MultiClusterServiceSpec</a>)
+</p>
+<p>
+<p>PortSpec contains information on service&rsquo;s port.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Port</code><br/>
+<em>
+uint32
+</em>
+</td>
+<td>
+<p>The port that will be exposed by this service.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>Protocol</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Protocol is The IP protocol for this port. Supports &ldquo;TCP&rdquo;, &ldquo;UDP&rdquo;, and &ldquo;SCTP&rdquo;. Default is TCP.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="config.openservicemesh.io/v1alpha1.SidecarSpec">SidecarSpec
 </h3>
 <p>
@@ -602,7 +845,7 @@ string
 </em>
 </td>
 <td>
-<p>LogLevel defines the  logging level for the sidecar&rsquo;s logs.</p>
+<p>LogLevel defines the logging level for the sidecar&rsquo;s logs. Non developers should generally never set this value. In production environments the LogLevel should be set to error.</p>
 </td>
 </tr>
 <tr>
@@ -799,17 +1042,6 @@ bool
 </tr>
 <tr>
 <td>
-<code>useHTTPSIngress</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>UseHTTPSIngress defines a boolean indicating if HTTPS Ingress is enabled globally in the mesh.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>enablePermissiveTrafficPolicyMode</code><br/>
 <em>
 bool
@@ -838,5 +1070,5 @@ for all inbound and ingress traffic in the mesh.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>8ed34b1d</code>.
+on git commit <code>386d92a1</code>.
 </em></p>

--- a/content/docs/api_reference/policy/v1alpha1.md
+++ b/content/docs/api_reference/policy/v1alpha1.md
@@ -432,6 +432,20 @@ IngressBackendSpec
 </table>
 </td>
 </tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.IngressBackendStatus">
+IngressBackendStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status is the status of the IngressBackend configuration.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="policy.openservicemesh.io/v1alpha1.IngressBackendSpec">IngressBackendSpec
@@ -492,6 +506,48 @@ IngressBackendSpec
 </tr>
 </tbody>
 </table>
+<h3 id="policy.openservicemesh.io/v1alpha1.IngressBackendStatus">IngressBackendStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.IngressBackend">IngressBackend</a>)
+</p>
+<p>
+<p>IngressBackendStatus is the type used to represent the status of an IngressBackend resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>currentStatus</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CurrentStatus defines the current status of an IngressBackend resource.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reason defines the reason for the current status of an IngressBackend resource.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="policy.openservicemesh.io/v1alpha1.IngressSourceSpec">IngressSourceSpec
 </h3>
 <p>
@@ -517,7 +573,8 @@ string
 </em>
 </td>
 <td>
-<p>Kind defines the kind for the source in the IngressBackend policy.</p>
+<p>Kind defines the kind for the source in the IngressBackend policy.
+Must be one of: Service, AuthenticatedPrincipal, IPRange</p>
 </td>
 </tr>
 <tr>
@@ -630,5 +687,5 @@ certificate presented by the client.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>8ed34b1d</code>.
+on git commit <code>386d92a1</code>.
 </em></p>


### PR DESCRIPTION
Updates the API reference docs and clarifies the usage of
the different source kinds that can be specified in an
IngressBackend config.

Part of openservicemesh/osm#4391