### PR TITLE
demos/ingress: clarify subject name usage

### DIFF
--- a/content/docs/demos/ingress_contour.md
+++ b/content/docs/demos/ingress_contour.md
@@ -166,6 +166,8 @@ spec:
       port: 14001
       validation:
         caSecret: "$osm_namespace/osm-ca-bundle"
+        # subjectName for a service is of the form <service-account>.<namespace>.cluster.local
+        # where the service account and namespace is that of the pod backing the service
         subjectName: httpbin.httpbin.cluster.local
 ---
 kind: IngressBackend


### PR DESCRIPTION
Clarifies the subject name used for backend TLS.