### PR TITLE
manifests: store docs manifests in same repo

### DIFF
--- a/content/docs/demos/canary_rollout.md
+++ b/content/docs/demos/canary_rollout.md
@@ -42,7 +42,7 @@ The following steps demonstrate the canary rollout deployment strategy.
     osm namespace add curl
 
     # Deploy curl client in the curl namespace
-    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/samples/curl/curl.yaml -n curl
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/curl/curl.yaml -n curl
     ```
 
     Confirm the `curl` client pod is up and running.
@@ -62,13 +62,13 @@ The following steps demonstrate the canary rollout deployment strategy.
     osm namespace add httpbin
 
     # Create the httpbin root service and service account
-    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/samples/canary/httpbin.yaml -n httpbin
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/canary/httpbin.yaml -n httpbin
     ```
 
 1. Deploy version `v1` of the `httpbin` service. The service `httpbin-v1` has the selector `app: httpbin, version: v1`, and the deployment `httpbin-v1` has the labels `app: httpbin, version: v1` matching the selector of both the `httpbin` root service and `httpbin-v1` service.
 
     ```bash
-    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/samples/canary/httpbin-v1.yaml -n httpbin
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/canary/httpbin-v1.yaml -n httpbin
     ```
 
 1. Create an SMI TrafficSplit resource that directs all traffic to the `httpbin-v1` service.
@@ -119,7 +119,7 @@ The following steps demonstrate the canary rollout deployment strategy.
 1. Prepare the canary rollout by deploying version `v2` of the `httpbin` service. The service `httpbin-v2` has the selector `app: httpbin, version: v2`, and the deployment `httpbin-v2` has the labels `app: httpbin, version: v2` matching the selector of both the `httpbin` root service and `httpbin-v2` service.
 
     ```bash
-    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/samples/canary/httpbin-v2.yaml -n httpbin
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/canary/httpbin-v2.yaml -n httpbin
     ```
 
 1. Perform the canary rollout by updating the SMI TrafficSplit resource to split traffic directed to the root service FQDN `httpbin.httpbin.svc.cluster.local` to both the `httpbin-v1` and `httpbin-v2` services, fronting the `v1` and `v2` versions of the `httpbin` service respectively. We will distribute the weight equally to demonstrate traffic splitting.

--- a/content/docs/demos/egress_passthrough.md
+++ b/content/docs/demos/egress_passthrough.md
@@ -33,7 +33,7 @@ This guide demonstrates a client within the service mesh accessing destinations 
     osm namespace add curl
 
     # Deploy curl client in the curl namespace
-    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/samples/curl/curl.yaml -n curl
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/curl/curl.yaml -n curl
     ```
 
     Confirm the `curl` client pod is up and running.

--- a/content/docs/demos/egress_policy.md
+++ b/content/docs/demos/egress_policy.md
@@ -33,7 +33,7 @@ This guide demonstrates a client within the service mesh accessing destinations 
     osm namespace add curl
 
     # Deploy curl client in the curl namespace
-    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/samples/curl/curl.yaml -n curl
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/curl/curl.yaml -n curl
     ```
 
     Confirm the `curl` client pod is up and running.

--- a/content/docs/demos/ingress_contour.md
+++ b/content/docs/demos/ingress_contour.md
@@ -62,7 +62,7 @@ kubectl create ns httpbin
 osm namespace add httpbin
 
 # Deploy the application
-kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/samples/httpbin/httpbin.yaml -n httpbin
+kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/httpbin/httpbin.yaml -n httpbin
 ```
 
 Confirm the `httpbin` service and pod is up and running:

--- a/content/docs/demos/ingress_k8s_nginx.md
+++ b/content/docs/demos/ingress_k8s_nginx.md
@@ -43,7 +43,7 @@ kubectl create ns httpbin
 osm namespace add httpbin
 
 # Deploy the application
-kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/samples/httpbin/httpbin.yaml -n httpbin
+kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/httpbin/httpbin.yaml -n httpbin
 ```
 
 Confirm the `httpbin` service and pod is up and running:

--- a/content/docs/demos/outbound_ip_exclusion.md
+++ b/content/docs/demos/outbound_ip_exclusion.md
@@ -35,7 +35,7 @@ The following demo shows an HTTP `curl` client making HTTP requests to the `http
     osm namespace add curl
 
     # Deploy curl client in the curl namespace
-    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/samples/curl/curl.yaml -n curl
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/curl/curl.yaml -n curl
     ```
 
     Confirm the `curl` client pod is up and running.

--- a/content/docs/demos/permissive_traffic_mode.md
+++ b/content/docs/demos/permissive_traffic_mode.md
@@ -36,7 +36,7 @@ The following demo shows an HTTP `curl` client making HTTP requests to the `http
     osm namespace add httpbin
 
     # Deploy httpbin service in the httpbin namespace
-    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/samples/httpbin/httpbin.yaml -n httpbin
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/httpbin/httpbin.yaml -n httpbin
     ```
 
     Confirm the `httpbin` service and pods are up and running.
@@ -63,7 +63,7 @@ The following demo shows an HTTP `curl` client making HTTP requests to the `http
     osm namespace add curl
 
     # Deploy curl client in the curl namespace
-    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/samples/curl/curl.yaml -n curl
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/curl/curl.yaml -n curl
     ```
 
     Confirm the `curl` client pod is up and running.

--- a/content/docs/demos/tcp_traffic_routing.md
+++ b/content/docs/demos/tcp_traffic_routing.md
@@ -34,7 +34,7 @@ The following demo shows a TCP client sending data to a `tcp-echo` server, which
     osm namespace add tcp-demo
 
     # Deploy the service
-    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/apps/tcp-echo.yaml -n tcp-demo
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/apps/tcp-echo.yaml -n tcp-demo
     ```
 
     Confirm the `tcp-echo` service and pod is up and running.
@@ -58,7 +58,7 @@ The following demo shows a TCP client sending data to a `tcp-echo` server, which
     osm namespace add curl
 
     # Deploy curl client in the curl namespace
-    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/samples/curl/curl.yaml -n curl
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/curl/curl.yaml -n curl
     ```
 
     Confirm the `curl` client pod is up and running.

--- a/content/docs/getting_started/install_apps.md
+++ b/content/docs/getting_started/install_apps.md
@@ -21,12 +21,12 @@ We are going to define and deploy traffic access policies using [SMI](https://sm
 state of allowed and blocked traffic between pods:
 
 | from  /   to: | bookbuyer | bookthief | bookstore | bookwarehouse | mysql |
-|---------------|-----------|-----------|-----------|---------------|-------|
-| bookbuyer     |     n/a   |     ❌    |     ✔     |      ❌       |  ❌   |
-| bookthief     |     ❌    |     n/a   |     ❌    |      ❌       |  ❌   |
-| bookstore     |     ❌    |     ❌    |     n/a   |      ✔        |  ❌   |
-| bookwarehouse |     ❌    |     ❌    |     ❌    |      n/a      |  ✔    |
-| mysql         |     ❌    |     ❌    |     ❌    |      ❌       |  n/a  |
+| ------------- | --------- | --------- | --------- | ------------- | ----- |
+| bookbuyer     | n/a       | ❌         | ✔         | ❌             | ❌     |
+| bookthief     | ❌         | n/a       | ❌         | ❌             | ❌     |
+| bookstore     | ❌         | ❌         | n/a       | ✔             | ❌     |
+| bookwarehouse | ❌         | ❌         | ❌         | n/a           | ✔     |
+| mysql         | ❌         | ❌         | ❌         | ❌             | n/a   |
 
 
 To show how to split traffic using SMI Traffic Split, we will deploy an additional application:
@@ -60,31 +60,31 @@ on these namespaces, will start injecting all **new** pods with Envoy sidecars.
 Create the `bookbuyer` service account and deployment:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/apps/bookbuyer.yaml
+kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/apps/bookbuyer.yaml
 ```
 
 Create the `bookthief` service account and deployment:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/apps/bookthief.yaml
+kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/apps/bookthief.yaml
 ```
 
 Create the `bookstore` service account, service, and deployment:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/apps/bookstore.yaml
+kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/apps/bookstore.yaml
 ```
 
 Create the `bookwarehouse` service account, service, and deployment:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/apps/bookwarehouse.yaml
+kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/apps/bookwarehouse.yaml
 ```
 
 Create the `mysql` service account, service, and stateful set:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/apps/mysql.yaml
+kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/apps/mysql.yaml
 ```
 
 ### Checkpoint: What Got Installed?

--- a/content/docs/getting_started/traffic_policies.md
+++ b/content/docs/getting_started/traffic_policies.md
@@ -47,7 +47,7 @@ In permissive traffic policy mode, application connectivity within the mesh is a
 
 Before proceeding, [verify the traffic policy mode](#verify-the-traffic-policy-mode) and ensure the `enablePermissiveTrafficPolicyMode` key is set to `true` in the `osm-mesh-config` `MeshConfig` resource. Refer to the section above to enable permissive traffic policy mode.
 
-In step [Deploy the Bookstore Application](#deploy-the-bookstore-application), we have already deployed the applications needed to verify traffic flow in permissive traffic policy mode. The `bookstore` service we previously deployed is encoded with an identity of `bookstore-v1` for demo purpose, as can be seen in the [Deployment's manifest](https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/apps/bookstore.yaml). The identity reflects which counter increments in the `bookbuyer` and `bookthief` UI, and the identity displayed in the `bookstore` UI.
+In step [Deploy the Bookstore Application](#deploy-the-bookstore-application), we have already deployed the applications needed to verify traffic flow in permissive traffic policy mode. The `bookstore` service we previously deployed is encoded with an identity of `bookstore-v1` for demo purpose, as can be seen in the [Deployment's manifest](https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/apps/bookstore.yaml). The identity reflects which counter increments in the `bookbuyer` and `bookthief` UI, and the identity displayed in the `bookstore` UI.
 
 The counter in the `bookbuyer`, `bookthief` UI for the books bought and stolen respectively from `bookstore v1` should now be incrementing:
 
@@ -93,7 +93,7 @@ Apply the [SMI Traffic Target][https://github.com/servicemeshinterface/smi-spec/
  Deploy SMI TrafficTarget and HTTPRouteGroup policy:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/access/traffic-access-v1.yaml
+kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/access/traffic-access-v1.yaml
 ```
 
 The counters should now be incrementing for the `bookbuyer`, and `bookstore` applications:
@@ -167,7 +167,7 @@ spec:
 Apply the updated TrafficTarget:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/access/traffic-access-v1-allow-bookthief.yaml
+kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/access/traffic-access-v1-allow-bookthief.yaml
 ```
 
 The counter in the `bookthief` window will start incrementing.
@@ -177,7 +177,7 @@ The counter in the `bookthief` window will start incrementing.
 Apply the original Traffic Target object without the bookthief listed as an allowed source:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/access/traffic-access-v1.yaml
+kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/access/traffic-access-v1.yaml
 ```
 
 The counter in the `bookthief` window will stop incrementing.

--- a/content/docs/getting_started/traffic_split.md
+++ b/content/docs/getting_started/traffic_split.md
@@ -16,7 +16,7 @@ To demonstrate usage of SMI traffic access and split policies, we will now deplo
 ```bash
 # Contains the bookstore-v2 Kubernetes Service, Service Account, Deployment and SMI Traffic Target resource to allow
 # `bookbuyer` to communicate with `bookstore-v2` pods
-kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/apps/bookstore-v2.yaml
+kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/apps/bookstore-v2.yaml
 ```
 
 Wait for the `bookstore-v2` pod to be running in the `bookstore` namespace. Next, exit and restart the `./scripts/port-forward-all.sh` script in order to access v2 of bookstore.
@@ -30,7 +30,7 @@ The counter should _not_ be incrementing because no traffic is flowing yet to th
 Deploy the SMI traffic split policy to direct 100 percent of the traffic sent to the root `bookstore` service to the `bookstore` service backend:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/split/traffic-split-v1.yaml
+kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/split/traffic-split-v1.yaml
 ```
 
 _Note: The root service can be any Kubernetes service. It does not have any label selectors. It also doesn't need to overlap with any of the Backend services specified in the Traffic Split resource. The root service can be referred to in the SMI Traffic Split resource as the name of the service with or without the `.<namespace>` suffix._
@@ -46,7 +46,7 @@ kubectl describe trafficsplit bookstore-split -n bookstore
 Update the SMI Traffic Split policy to direct 50 percent of the traffic sent to the root `bookstore` service to the `bookstore` service and 50 perfect to `bookstore-v2` service by adding the `bookstore-v2` backend to the spec and modifying the weight fields.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/split/traffic-split-50-50.yaml
+kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/split/traffic-split-50-50.yaml
 ```
 
 Wait for the changes to propagate and observe the counters increment for `bookstore` and `bookstore-v2` in your browser windows. Both
@@ -60,7 +60,7 @@ counters should be incrementing:
 Update the `bookstore-split` TrafficSplit to configure all traffic to go to `bookstore-v2`:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/split/traffic-split-v2.yaml
+kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/split/traffic-split-v2.yaml
 ```
 
 Wait for the changes to propagate and observe the counters increment for `bookstore-v2` and freeze for `bookstore` in your

--- a/content/docs/guides/integrations/external_auth_opa.md
+++ b/content/docs/guides/integrations/external_auth_opa.md
@@ -33,11 +33,11 @@ cd <PATH_TO_OSM_REPO>
 demo/run-osm-demo.sh  # wait for all services to come up
 ```
 
-- When OSM's demo is up and running, proceed to deploy `opa-envoy-plugin`. OSM provides a [curated standalone opa-envoy-plugin deployment chart](https://github.com/openservicemesh/osm/blob/{{< param osm_branch >}}/docs/example/manifests/opa/deploy-opa-envoy.yaml) which exposes `opa-envoy-plugin`'s gRPC port (default `9191`) through a service, over the network. This is the endpoint that OSM will configure the proxies with when enabling external authorization. The following snippet creates an `opa` namespace and deploys `opa-envoy-plugin` in it with minimal deny-all configuration:
+- When OSM's demo is up and running, proceed to deploy `opa-envoy-plugin`. OSM provides a [curated standalone opa-envoy-plugin deployment chart](https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/opa/deploy-opa-envoy.yaml) which exposes `opa-envoy-plugin`'s gRPC port (default `9191`) through a service, over the network. This is the endpoint that OSM will configure the proxies with when enabling external authorization. The following snippet creates an `opa` namespace and deploys `opa-envoy-plugin` in it with minimal deny-all configuration:
 
 ```
 kubectl create namespace opa
-kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/{{< param osm_branch >}}/docs/example/manifests/opa/deploy-opa-envoy.yaml
+kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/opa/deploy-opa-envoy.yaml
 ```
 
 - Once OSM's demo is up and running, proceed to edit OSM's MeshConfig to add external authorization to the mesh. For that, configure the `inboundExternalAuthorization` to point to the remote external authorization endpoint as follows:

--- a/content/docs/guides/integrations/prometheus.md
+++ b/content/docs/guides/integrations/prometheus.md
@@ -43,10 +43,10 @@ To familiarize yourself on how OSM works with Prometheus, try installing a new m
 1. Install sample applications:
 
    ```console
-   $ kubectl apply -f docs/example/manifests/samples/curl/curl.yaml -n metrics-demo
+   $ kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/curl/curl.yaml -n metrics-demo
    serviceaccount/curl created
    deployment.apps/curl created
-   $ kubectl apply -f docs/example/manifests/samples/httpbin/httpbin.yaml -n metrics-demo
+   $ kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/httpbin/httpbin.yaml -n metrics-demo
    serviceaccount/httpbin created
    service/httpbin created
    deployment.apps/httpbin created

--- a/manifests/access/traffic-access-v1-allow-bookthief.yaml
+++ b/manifests/access/traffic-access-v1-allow-bookthief.yaml
@@ -1,0 +1,101 @@
+kind: TrafficTarget
+apiVersion: access.smi-spec.io/v1alpha3
+metadata:
+  name: bookstore
+  namespace: bookstore
+spec:
+  destination:
+    kind: ServiceAccount
+    name: bookstore
+    namespace: bookstore
+  rules:
+  - kind: HTTPRouteGroup
+    name: bookstore-service-routes
+    matches:
+    - buy-a-book
+    - books-bought
+  sources:
+  - kind: ServiceAccount
+    name: bookbuyer
+    namespace: bookbuyer
+  - kind: ServiceAccount
+    name: bookthief
+    namespace: bookthief
+---
+apiVersion: specs.smi-spec.io/v1alpha4
+kind: HTTPRouteGroup
+metadata:
+  name: bookstore-service-routes
+  namespace: bookstore
+spec:
+  matches:
+  - name: books-bought
+    pathRegex: /books-bought
+    methods:
+    - GET
+    headers:
+    - "user-agent": ".*-http-client/*.*"
+    - "client-app": "bookbuyer"
+  - name: buy-a-book
+    pathRegex: ".*a-book.*new"
+    methods:
+    - GET
+---
+kind: TrafficTarget
+apiVersion: access.smi-spec.io/v1alpha3
+metadata:
+  name: bookstore-access-bookwarehouse
+  namespace: bookwarehouse
+spec:
+  destination:
+    kind: ServiceAccount
+    name: bookwarehouse
+    namespace: bookwarehouse
+  rules:
+  - kind: HTTPRouteGroup
+    name: bookwarehouse-service-routes
+    matches:
+    - restock-books
+  sources:
+  - kind: ServiceAccount
+    name: bookstore
+    namespace: bookstore
+---
+apiVersion: specs.smi-spec.io/v1alpha4
+kind: HTTPRouteGroup
+metadata:
+  name: bookwarehouse-service-routes
+  namespace: bookwarehouse
+spec:
+  matches:
+    - name: restock-books
+      methods:
+      - POST
+---
+kind: TrafficTarget
+apiVersion: access.smi-spec.io/v1alpha3
+metadata:
+  name: mysql
+  namespace: bookwarehouse
+spec:
+  destination:
+    kind: ServiceAccount
+    name: mysql
+    namespace: bookwarehouse
+  rules:
+  - kind: TCPRoute
+    name: mysql
+  sources:
+  - kind: ServiceAccount
+    name: bookwarehouse
+    namespace: bookwarehouse
+---
+apiVersion: specs.smi-spec.io/v1alpha4
+kind: TCPRoute
+metadata:
+  name: mysql
+  namespace: bookwarehouse
+spec:
+  matches:
+    ports:
+    - 3306

--- a/manifests/access/traffic-access-v1.yaml
+++ b/manifests/access/traffic-access-v1.yaml
@@ -1,0 +1,98 @@
+kind: TrafficTarget
+apiVersion: access.smi-spec.io/v1alpha3
+metadata:
+  name: bookstore
+  namespace: bookstore
+spec:
+  destination:
+    kind: ServiceAccount
+    name: bookstore
+    namespace: bookstore
+  rules:
+  - kind: HTTPRouteGroup
+    name: bookstore-service-routes
+    matches:
+    - buy-a-book
+    - books-bought
+  sources:
+  - kind: ServiceAccount
+    name: bookbuyer
+    namespace: bookbuyer
+---
+apiVersion: specs.smi-spec.io/v1alpha4
+kind: HTTPRouteGroup
+metadata:
+  name: bookstore-service-routes
+  namespace: bookstore
+spec:
+  matches:
+  - name: books-bought
+    pathRegex: /books-bought
+    methods:
+    - GET
+    headers:
+    - "user-agent": ".*-http-client/*.*"
+    - "client-app": "bookbuyer"
+  - name: buy-a-book
+    pathRegex: ".*a-book.*new"
+    methods:
+    - GET
+---
+kind: TrafficTarget
+apiVersion: access.smi-spec.io/v1alpha3
+metadata:
+  name: bookstore-access-bookwarehouse
+  namespace: bookwarehouse
+spec:
+  destination:
+    kind: ServiceAccount
+    name: bookwarehouse
+    namespace: bookwarehouse
+  rules:
+  - kind: HTTPRouteGroup
+    name: bookwarehouse-service-routes
+    matches:
+    - restock-books
+  sources:
+  - kind: ServiceAccount
+    name: bookstore
+    namespace: bookstore
+---
+apiVersion: specs.smi-spec.io/v1alpha4
+kind: HTTPRouteGroup
+metadata:
+  name: bookwarehouse-service-routes
+  namespace: bookwarehouse
+spec:
+  matches:
+    - name: restock-books
+      methods:
+      - POST
+---
+kind: TrafficTarget
+apiVersion: access.smi-spec.io/v1alpha3
+metadata:
+  name: mysql
+  namespace: bookwarehouse
+spec:
+  destination:
+    kind: ServiceAccount
+    name: mysql
+    namespace: bookwarehouse
+  rules:
+  - kind: TCPRoute
+    name: mysql
+  sources:
+  - kind: ServiceAccount
+    name: bookwarehouse
+    namespace: bookwarehouse
+---
+apiVersion: specs.smi-spec.io/v1alpha4
+kind: TCPRoute
+metadata:
+  name: mysql
+  namespace: bookwarehouse
+spec:
+  matches:
+    ports:
+    - 3306

--- a/manifests/apps/bookbuyer.yaml
+++ b/manifests/apps/bookbuyer.yaml
@@ -1,0 +1,41 @@
+# Create bookbuyer Service Account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookbuyer
+  namespace: bookbuyer
+
+---
+
+# Create bookbuyer Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bookbuyer
+  namespace: bookbuyer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bookbuyer
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: bookbuyer
+        version: v1
+    spec:
+      serviceAccountName: bookbuyer
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      containers:
+        - name: bookbuyer
+          image: openservicemesh/bookbuyer:latest-main
+          imagePullPolicy: Always
+          command: ["/bookbuyer"]
+          env:
+            - name: "BOOKSTORE_NAMESPACE"
+              value: bookstore
+            - name: "BOOKSTORE_SVC"
+              value: bookstore

--- a/manifests/apps/bookstore-v2.yaml
+++ b/manifests/apps/bookstore-v2.yaml
@@ -1,0 +1,83 @@
+# Create bookstore-v2 Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: bookstore-v2
+  namespace: bookstore
+  labels:
+    app: bookstore-v2
+spec:
+  ports:
+  - port: 14001
+    name: bookstore-port
+  selector:
+    app: bookstore-v2
+
+---
+
+# Create bookstore-v2 Service Account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookstore-v2
+  namespace: bookstore
+
+---
+
+# Create bookstore-v2 Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bookstore-v2
+  namespace: bookstore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bookstore-v2
+  template:
+    metadata:
+      labels:
+        app: bookstore-v2
+    spec:
+      serviceAccountName: bookstore-v2
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      containers:
+        - name: bookstore
+          image: openservicemesh/bookstore:latest-main
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 14001
+              name: web
+          command: ["/bookstore"]
+          args: ["--port", "14001"]
+          env:
+            - name: BOOKWAREHOUSE_NAMESPACE
+              value: bookwarehouse
+            - name: IDENTITY
+              value: bookstore-v2
+
+---
+
+kind: TrafficTarget
+apiVersion: access.smi-spec.io/v1alpha3
+metadata:
+  name: bookstore-v2
+  namespace: bookstore
+spec:
+  destination:
+    kind: ServiceAccount
+    name: bookstore-v2
+    namespace: bookstore
+  rules:
+  - kind: HTTPRouteGroup
+    name: bookstore-service-routes
+    matches:
+    - buy-a-book
+    - books-bought
+  sources:
+  - kind: ServiceAccount
+    name: bookbuyer
+    namespace: bookbuyer

--- a/manifests/apps/bookstore.yaml
+++ b/manifests/apps/bookstore.yaml
@@ -1,0 +1,60 @@
+# Create bookstore Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: bookstore
+  namespace: bookstore
+  labels:
+    app: bookstore
+spec:
+  ports:
+  - port: 14001
+    name: bookstore-port
+  selector:
+    app: bookstore
+
+---
+
+# Create bookstore Service Account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookstore
+  namespace: bookstore
+
+---
+
+# Create bookstore Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bookstore
+  namespace: bookstore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bookstore
+  template:
+    metadata:
+      labels:
+        app: bookstore
+    spec:
+      serviceAccountName: bookstore
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      containers:
+        - name: bookstore
+          image: openservicemesh/bookstore:latest-main
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 14001
+              name: web
+          command: ["/bookstore"]
+          args: ["--port", "14001"]
+          env:
+            - name: BOOKWAREHOUSE_NAMESPACE
+              value: bookwarehouse
+            - name: IDENTITY
+              value: bookstore-v1

--- a/manifests/apps/bookthief.yaml
+++ b/manifests/apps/bookthief.yaml
@@ -1,0 +1,42 @@
+# Create bookthief ServiceAccount
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookthief
+  namespace: bookthief
+
+---
+
+# Create bookthief Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bookthief
+  namespace: bookthief
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bookthief
+  template:
+    metadata:
+      labels:
+        app: bookthief
+        version: v1
+    spec:
+      serviceAccountName: bookthief
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      containers:
+        - name: bookthief
+          image: openservicemesh/bookthief:latest-main
+          imagePullPolicy: Always
+          command: ["/bookthief"]
+          env:
+            - name: "BOOKSTORE_NAMESPACE"
+              value: bookstore
+            - name: "BOOKSTORE_SVC"
+              value: bookstore
+            - name: "BOOKTHIEF_EXPECTED_RESPONSE_CODE"
+              value: "503"

--- a/manifests/apps/bookwarehouse.yaml
+++ b/manifests/apps/bookwarehouse.yaml
@@ -1,0 +1,52 @@
+# Create bookwarehouse Service Account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookwarehouse
+  namespace: bookwarehouse
+
+---
+
+# Create bookwarehouse Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: bookwarehouse
+  namespace: bookwarehouse
+  labels:
+    app: bookwarehouse
+spec:
+  ports:
+  - port: 14001
+    name: bookwarehouse-port
+  selector:
+    app: bookwarehouse
+
+---
+
+# Create bookwarehouse Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bookwarehouse
+  namespace: bookwarehouse
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bookwarehouse
+  template:
+    metadata:
+      labels:
+        app: bookwarehouse
+        version: v1
+    spec:
+      serviceAccountName: bookwarehouse
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      containers:
+        - name: bookwarehouse
+          image: openservicemesh/bookwarehouse:latest-main
+          imagePullPolicy: Always
+          command: ["/bookwarehouse"]

--- a/manifests/apps/mysql.yaml
+++ b/manifests/apps/mysql.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql
+  namespace: bookwarehouse
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: bookwarehouse
+spec:
+  ports:
+  - port: 3306
+    targetPort: 3306
+    name: client
+    appProtocol: tcp
+  selector:
+    app: mysql
+  clusterIP: None
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  namespace: bookwarehouse
+spec:
+  serviceName: mysql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      serviceAccountName: mysql
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+      - image: mysql:5.6
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: mypassword
+        - name: MYSQL_DATABASE
+          value: booksdemo
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - mountPath: /mysql-data
+          name: data
+        readinessProbe:
+          tcpSocket:
+            port: 3306
+          initialDelaySeconds: 15
+          periodSeconds: 10
+      volumes:
+        - name: data
+          emptyDir: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 250M

--- a/manifests/apps/tcp-echo.yaml
+++ b/manifests/apps/tcp-echo.yaml
@@ -1,0 +1,55 @@
+# Note: create and add the `tcp-demo` namespace to the mesh prior to deploying this app
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-echo
+  namespace: tcp-demo
+  labels:
+    app: tcp-echo
+spec:
+  ports:
+  - name: tcp
+    port: 9000
+    appProtocol: tcp # required for TCP based routing
+  selector:
+    app: tcp-echo
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tcp-echo
+  namespace: tcp-demo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcp-echo
+  namespace: tcp-demo
+  labels:
+    app: tcp-echo
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tcp-echo
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: tcp-echo
+        version: v1
+    spec:
+      serviceAccountName: tcp-echo
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      containers:
+      - name: tcp-echo-server
+        image: "openservicemesh/tcp-echo-server:latest"
+        imagePullPolicy: Always
+        command: ["/tcp-echo-server"]
+        args: [ "--port", "9000" ]
+        ports:
+        - containerPort: 9000
+          name: tcp-echo-server

--- a/manifests/meshconfig/mesh-config.yaml
+++ b/manifests/meshconfig/mesh-config.yaml
@@ -1,0 +1,24 @@
+apiVersion: config.openservicemesh.io/v1alpha1
+kind: MeshConfig
+metadata:
+  name: osm-mesh-config
+spec:
+  sidecar:
+    enablePrivilegedInitContainer: false
+    logLevel: error
+    maxDataPlaneConnections: 0
+    envoyImage: "envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd"
+    initContainerImage: "openservicemesh/init:latest-main"
+    configResyncInterval: "0s"
+  traffic:
+    enableEgress: false
+    enablePermissiveTrafficPolicyMode: true
+  observability:
+    enableDebugServer: true
+    outboundPortExclusionList: []
+    inboundPortExclusionList: []
+    outboundIPRangeExclusionList: []
+    tracing:
+      enable: false
+  certificate:
+    serviceCertValidityDuration: 24h

--- a/manifests/opa/deploy-opa-envoy.yaml
+++ b/manifests/opa/deploy-opa-envoy.yaml
@@ -1,0 +1,102 @@
+####################################################
+# App Deployment with OPA-Envoy and Envoy sidecars.
+####################################################
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opa
+  namespace: opa
+  labels:
+    app: opa
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opa
+  template:
+    metadata:
+      labels:
+        app: opa
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      containers:
+        - name: opa-envoy
+          image: openpolicyagent/opa:0.28.0-envoy
+          securityContext:
+            runAsUser: 1111
+          volumeMounts:
+            - readOnly: true
+              mountPath: /policy
+              name: opa-policy
+            - readOnly: true
+              mountPath: /config
+              name: opa-envoy-config
+          args:
+            - "run"
+            - "--server"
+            - "--config-file=/config/config.yaml"
+            - "--addr=0.0.0.0:8181"
+            - "--diagnostic-addr=0.0.0.0:8282"
+            - "--ignore=.*"
+            - "/policy/policy.rego"
+      volumes:
+        - name: proxy-config
+          configMap:
+            name: proxy-config
+        - name: opa-policy
+          configMap:
+            name: opa-policy
+        - name: opa-envoy-config
+          configMap:
+            name: opa-envoy-config
+---
+############################################################
+# Example configuration to bootstrap OPA-Envoy sidecars.
+############################################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opa-envoy-config
+  namespace: opa
+data:
+  config.yaml: |
+    plugins:
+      envoy_ext_authz_grpc:
+        addr: :9191
+        path: envoy/authz/allow
+    decision_logs:
+      console: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opa
+  namespace: opa
+  labels:
+    app: opa
+spec:
+  ports:
+  - port: 9191
+    protocol: TCP
+    targetPort: 9191
+  selector:
+    app: opa
+---
+############################################################
+# Example policy to enforce into OPA-Envoy sidecars.
+############################################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opa-policy
+  namespace: opa
+data:
+  policy.rego: |
+    package envoy.authz
+
+    import input.attributes.request.http as http_request
+
+    default allow = false
+---

--- a/manifests/samples/canary/httpbin-split.yaml
+++ b/manifests/samples/canary/httpbin-split.yaml
@@ -1,0 +1,12 @@
+apiVersion: split.smi-spec.io/v1alpha2
+kind: TrafficSplit
+metadata:
+  name: http-split
+  namespace: httpbin
+spec:
+  service: httpbin.httpbin
+  backends:
+  - service: httpbin-v1
+    weight: 50
+  - service: httpbin-v2
+    weight: 50

--- a/manifests/samples/canary/httpbin-v1.yaml
+++ b/manifests/samples/canary/httpbin-v1.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin-v1
+  namespace: httpbin
+  labels:
+    app: httpbin
+    version: v1
+spec:
+  ports:
+  - name: http
+    port: 14001
+  selector:
+    app: httpbin
+    version: v1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin-v1
+  namespace: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: httpbin
+        version: v1
+    spec:
+      serviceAccountName: httpbin
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      containers:
+      - image: simonkowallik/httpbin
+        imagePullPolicy: IfNotPresent
+        name: httpbin
+        command: ["gunicorn", "-b", "0.0.0.0:14001", "httpbin:app", "-k", "gevent"]
+        ports:
+        - containerPort: 14001
+        env:
+        - name: XHTTPBIN_POD
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/manifests/samples/canary/httpbin-v2.yaml
+++ b/manifests/samples/canary/httpbin-v2.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin-v2
+  namespace: httpbin
+  labels:
+    app: httpbin
+    version: v2
+spec:
+  ports:
+  - name: http
+    port: 14001
+  selector:
+    app: httpbin
+    version: v2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin-v2
+  namespace: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: httpbin
+        version: v2
+    spec:
+      serviceAccountName: httpbin
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      containers:
+      - image: simonkowallik/httpbin
+        imagePullPolicy: IfNotPresent
+        name: httpbin
+        command: ["gunicorn", "-b", "0.0.0.0:14001", "httpbin:app", "-k", "gevent"]
+        ports:
+        - containerPort: 14001
+        env:
+        - name: XHTTPBIN_POD
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/manifests/samples/canary/httpbin.yaml
+++ b/manifests/samples/canary/httpbin.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: httpbin
+  namespace: httpbin
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  namespace: httpbin
+  labels:
+    app: httpbin
+spec:
+  ports:
+  - name: http
+    port: 14001
+  selector:
+    app: httpbin

--- a/manifests/samples/curl/curl.yaml
+++ b/manifests/samples/curl/curl.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: curl
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: curl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: curl
+  template:
+    metadata:
+      labels:
+        app: curl
+    spec:
+      serviceAccountName: curl
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      containers:
+      - image: curlimages/curl
+        imagePullPolicy: IfNotPresent
+        name: curl
+        command: ["sleep", "365d"]

--- a/manifests/samples/httpbin/httpbin.yaml
+++ b/manifests/samples/httpbin/httpbin.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: httpbin
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  labels:
+    app: httpbin
+    service: httpbin
+spec:
+  ports:
+  - name: http
+    port: 14001
+  selector:
+    app: httpbin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+  template:
+    metadata:
+      labels:
+        app: httpbin
+    spec:
+      serviceAccountName: httpbin
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      containers:
+      - image: kennethreitz/httpbin
+        imagePullPolicy: IfNotPresent
+        name: httpbin
+        command: ["gunicorn", "-b", "0.0.0.0:14001", "httpbin:app", "-k", "gevent"]
+        ports:
+        - containerPort: 14001

--- a/manifests/split/traffic-split-50-50.yaml
+++ b/manifests/split/traffic-split-50-50.yaml
@@ -1,0 +1,12 @@
+apiVersion: split.smi-spec.io/v1alpha2
+kind: TrafficSplit
+metadata:
+  name: bookstore-split
+  namespace: bookstore
+spec:
+  service: bookstore.bookstore # <root-service>.<namespace>
+  backends:
+  - service: bookstore
+    weight: 50
+  - service: bookstore-v2
+    weight: 50

--- a/manifests/split/traffic-split-v1.yaml
+++ b/manifests/split/traffic-split-v1.yaml
@@ -1,0 +1,17 @@
+apiVersion: split.smi-spec.io/v1alpha2
+kind: TrafficSplit
+metadata:
+  name: bookstore-split
+  namespace: bookstore
+spec:
+# The root service is a Kubernetes Service FQDN. Because a Kubernetes Service FQDN can be a short form as well,
+# any of the following options are allowed and accepted values for the Service:
+#   - bookstore
+#   - bookstore.bookstore
+#   - bookstore.bookstore.svc
+#   - bookstore.bookstore.svc.cluster
+#   - bookstore.bookstore.svc.cluster.local
+  service: bookstore.bookstore # <root-service>.<namespace>
+  backends:
+  - service: bookstore
+    weight: 100

--- a/manifests/split/traffic-split-v2.yaml
+++ b/manifests/split/traffic-split-v2.yaml
@@ -1,0 +1,12 @@
+apiVersion: split.smi-spec.io/v1alpha2
+kind: TrafficSplit
+metadata:
+  name: bookstore-split
+  namespace: bookstore
+spec:
+  service: bookstore.bookstore # <root-service>.<namespace>
+  backends:
+  - service: bookstore
+    weight: 0
+  - service: bookstore-v2
+    weight: 100


### PR DESCRIPTION
Stores the manifests used by the docs repo
from osm/docs/examples/manifests in the osm-docs
repo. This makes it easier to update and maintain
the manifests used by the website without needing
to make changes across 2 repos.

Resolves #242