### PR TITLE
[backport] docs(metrics): clarify instructions for enabling metrics scraping (#321)

### DIFF
--- a/content/docs/getting_started/observability.md
+++ b/content/docs/getting_started/observability.md
@@ -29,6 +29,16 @@ When configured with the `--set=osm.deployPrometheus=true` flag, OSM installatio
 
 OSM can be configured to deploy a [Grafana](https://grafana.com/grafana/) instance using the `--set=osm.deployGrafana=true` flag in `osm install`. OSM provides pre-configured dashboards that are documented in the [OSM Grafana dashboards](/docs/guides/observability/metrics/#osm-grafana-dashboards) section of the Observability Guide.
 
+## Enable Metrics Scraping
+
+Metrics can be enabled at the namespace scope using the `osm metrics` command. By default, OSM **does not** configure metrics scraping for pods in the mesh. 
+```bash
+osm metrics enable --namespace test
+osm metrics enable --namespace "test1, test2"
+
+```
+> Note: The namespace that you are enabling for metrics scraping must already be a part of the mesh.
+
 ## Inspect Dashboards
 
 The OSM Grafana dashboards can be viewed with the following command:

--- a/content/docs/guides/observability/metrics.md
+++ b/content/docs/guides/observability/metrics.md
@@ -14,7 +14,7 @@ Additionally, OSM generates metrics for the control plane components. These metr
 
 OSM uses [Prometheus][1] to gather and store consistent traffic metrics and statistics for all applications running in the mesh. Prometheus is an open-source monitoring and alerting toolkit which is commonly used on (but not limited to) Kubernetes and Service Mesh environments.
 
-Each application that is part of the mesh runs in a Pod which contains an Envoy sidecar that exposes metrics (proxy metrics) in the Prometheus format. Furthermore, every Pod that is a part of the mesh has Prometheus annotations, which makes it possible for the Prometheus server to scrape the application dynamically. This mechanism automatically enables scraping of metrics whenever a pod is added to the mesh.
+Each application that is part of the mesh runs in a Pod which contains an Envoy sidecar that exposes metrics (proxy metrics) in the Prometheus format. Furthermore, every Pod that is a part of the mesh and in a namespace with metrics enabled has Prometheus annotations, which makes it possible for the Prometheus server to scrape the application dynamically. This mechanism automatically enables scraping of metrics whenever a pod is added to the mesh.
 
 OSM metrics can be viewed with [Grafana][8] which is an open source visualization and analytics software. It allows you to query, visualize, alert on, and explore your metrics.
 
@@ -163,8 +163,6 @@ prometheus.io/scrape: true
 prometheus.io/port: 15010
 prometheus.io/path: /stats/prometheus
 ```
-
-When metrics are disabled for a previously enabled meshed namespace, the existing pods in the namespace will still be configured for scraping. The pods must be recreated for the annotation to be removed. All future pods added to a namespace with metrics disabled will not be updated with the Prometheus annotations.
 
 ## Available Metrics
 


### PR DESCRIPTION
Backports c53b44d
---
Clarifies in the observability section of the getting started
guide that metrics scraping must be enabled on a namespace for the
pods in that namespace to be annotated by the osm injector. Also
adds this clarification to the metrics how to guide intro section.

Removes incorrect statement about pods needing to be recreated for
the annotations to be to added or removed corresponding to
metrics being enabled or disabled on the namespace.

Signed-off-by: jaellio <jaellio@microsoft.com>