### PR TITLE
release-v1.0: update redirect and release menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -87,7 +87,10 @@ osm_version = "v0.11.0"
 envoy_version = "v1.19.1"
 
 [[params.versions]]
-  version = "v0.11 (latest)"
+  version = "v1.0 (latest)"
+  url = "https://release-v1-0.docs.openservicemesh.io/"
+[[params.versions]]
+  version = "v0.11"
   url = "https://release-v0-11.docs.openservicemesh.io/"
 [[params.versions]]
   version = "v0.10"

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,5 +10,5 @@
 
 [[redirects]]
   from = "https://docs.openservicemesh.io/*"
-  to = "https://release-v0-11.docs.openservicemesh.io/:splat"
+  to = "https://release-v1-0.docs.openservicemesh.io/:splat"
   force = true


### PR DESCRIPTION
frontport(?) of #234 since the site still seems to redirect to v0.11