### PR TITLE
use single uninstall command to delete cluster wide resources

### DIFF
--- a/content/docs/getting_started/cleanup.md
+++ b/content/docs/getting_started/cleanup.md
@@ -27,10 +27,10 @@ osm uninstall mesh
 
 ## Uninstall OSM cluster-wide resources
 
-To uninstall OSM cluster-wide resources, use `osm uninstall cluster-wide-resources`.
+To uninstall OSM cluster-wide resources, use `osm uninstall mesh --delete-cluster-wide-resources`.
 
 ```bash
-osm uninstall cluster-wide-resources
+osm uninstall mesh --delete-cluster-wide-resources
 ```
 
 For more details about uninstalling OSM, see the [uninstallation guide](/docs/guides/uninstall/).

--- a/content/docs/guides/integrations/dapr.md
+++ b/content/docs/guides/integrations/dapr.md
@@ -307,5 +307,5 @@ This document walks you through the steps of getting Dapr working with OSM on a 
     4. To remove OSM's cluster wide resources after uninstallation, run the following command. See the [uninstall guide](/docs/guides/uninstall/) for more context and information.
 
        ```console
-       $ osm uninstall cluster-wide-resources
+       $ osm uninstall mesh --delete-cluster-wide-resources
        ```

--- a/content/docs/guides/integrations/prometheus.md
+++ b/content/docs/guides/integrations/prometheus.md
@@ -126,5 +126,5 @@ To familiarize yourself on how OSM works with Prometheus, try installing a new m
    To remove OSM's cluster wide resources after uninstallation, run the following command. See the [uninstall guide](/docs/guides/uninstall/) for more context and information.
 
    ```console
-   $ osm uninstall cluster-wide-resources
+   $ osm uninstall mesh --delete-cluster-wide-resources
    ```

--- a/content/docs/guides/troubleshooting/uninstall.md
+++ b/content/docs/guides/troubleshooting/uninstall.md
@@ -7,7 +7,7 @@ type: docs
 
 # OSM Mesh Uninstall Troubleshooting Guide
 
-If for any reason, `osm uninstall mesh` or `osm uninstall cluster-wide-resources` (as documented in the [uninstall guide](/docs/guides/uninstall/)) fails, you may manually delete OSM resources as detailed below.
+If for any reason, `osm uninstall mesh` (as documented in the [uninstall guide](/docs/guides/uninstall/)) fails, you may manually delete OSM resources as detailed below.
 
 Set environment variables for your mesh:
 ```console


### PR DESCRIPTION
Updated docs to replace `osm uninstall cluster-wide-resoures` with `osm
uninstall mesh --delete-cluster-wide-resources`

part of https://github.com/openservicemesh/osm/issues/4429

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>