### PR TITLE
docs(demo): add links for logical flow of getting started section

### DIFF
--- a/content/docs/getting_started/install_apps.md
+++ b/content/docs/getting_started/install_apps.md
@@ -129,3 +129,7 @@ In a browser, open up the following urls:
   - _Note: This page will not be available at this time in the demo. This will become available during the SMI Traffic Split configuration set up_
 
 Position the windows so that you can see all four at the same time. The header at the top of the webpage indicates the application and version.
+
+## Next Steps
+
+Now that the sample applications are running, [configure traffic policies](/docs/getting_started/traffic_policies/) between the applications.

--- a/content/docs/getting_started/observability.md
+++ b/content/docs/getting_started/observability.md
@@ -50,3 +50,7 @@ osm dashboard
 > Note: If you still have the additional terminal still running the `./scripts/port-forward-all.sh` script, go ahead and `CTRL+C` to terminate the port forwarding. The `osm dashboard` port redirection will not work simultaneously with the port forwarding script still running.
 
 Navigate to http://localhost:3000 to access the Grafana dashboards. The default user name is `admin` and the default password is `admin`. On the Grafana homepage click on the **Home** icon, you will see a folder containing dashboards for both OSM Control Plane and OSM Data Plane.
+
+## Next Steps
+
+[Cleanup sample applications and uninstall OSM](/docs/getting_started/cleanup/).

--- a/content/docs/getting_started/setup_osm.md
+++ b/content/docs/getting_started/setup_osm.md
@@ -75,3 +75,7 @@ osm install \
 ```
 
 Read more on OSM's integrations with Prometheus, Grafana, and Jaeger in the [observability documentation](/docs/guides/observability/).
+
+## Next Steps
+
+Now that the OSM control plane is up and running, [add applications](/docs/getting_started/install_apps/) to the mesh.

--- a/content/docs/getting_started/traffic_policies.md
+++ b/content/docs/getting_started/traffic_policies.md
@@ -183,3 +183,7 @@ kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< 
 The counter in the `bookthief` window will stop incrementing.
 
 - [http://localhost:8083](http://localhost:8083) - **bookthief**
+
+## Next Steps
+
+Learn how to balance traffic between services by [configuring traffic split](/docs/getting_started/traffic_split/).

--- a/content/docs/getting_started/traffic_split.md
+++ b/content/docs/getting_started/traffic_split.md
@@ -70,3 +70,8 @@ browser windows:
 - [http://localhost:8083](http://localhost:8084) - **bookstore**
 
 Now, all traffic directed to the `bookstore` service is flowing to `bookstore-v2`.
+
+## Next Steps
+
+- [Configure observability with Prometheus and Grafana](/docs/getting_started/observability/)
+- [Cleanup sample applications and uninstall OSM](/docs/getting_started/cleanup/)


### PR DESCRIPTION
Adds "Next steps" sections to the getting started pages to help users navigate the manual demo. Since this was split into several different pages, some of the natural flow is missing

Ex: the end of the Deploy Sample Applications page currently leaves a reader in suspense
<img width="548" alt="image" src="https://user-images.githubusercontent.com/42152676/152210635-1896edee-20bf-4438-95cb-565cc193ffe1.png">


Signed-off-by: Sanya Kochhar <kochhars@microsoft.com>