### PR TITLE
guides(app-onboarding): document app security context requirements

### DIFF
--- a/content/docs/guides/app_onboarding/prereqs.md
+++ b/content/docs/guides/app_onboarding/prereqs.md
@@ -8,9 +8,15 @@ weight: 1
 
 # Prerequisites
 
-## Application UIDs
+## Security Contexts
 
-Do not run applications with the user ID (UID) value of **1500**. This is **reserved** for the Envoy proxy sidecar container injected into pods by OSM's sidecar injector.
+* Do not run applications with the user ID (UID) value of **1500**. This is **reserved** for the Envoy proxy sidecar container injected into pods by OSM's sidecar injector.
+* If security context `runAsNonRoot` is set to `true` at the pod level, a `runAsUser` value must be provided either for the pod
+or for each container. If the UID is omitted, application containers may attempt to run as root user by default, causing conflict with the pod's security context.
+* Additional capabilities are not required.
+
+> Note: the OSM init container is programmed to run as root and add capability `NET_ADMIN` as it requires these security
+> contexts to finish scheduling. These values are not changed by application security contexts.
 
 ## Ports
 


### PR DESCRIPTION
* Documents security context requirements for applications
* Resolves https://github.com/openservicemesh/osm/issues/4388 and https://github.com/openservicemesh/osm/issues/4492

Signed-off-by: Sanya Kochhar <kochhars@microsoft.com>

**Testing done:**
- `runAsNonRoot` requires `runAsUser` to be set: 
   Omitting user ID causes the error `Error: container has runAsNonRoot and image will run as root` as seen here https://github.com/openservicemesh/osm/issues/4388
- No additional capabilities necessary:
  Containers with the following security context dropping capabilities did not error -
  ```
  capabilities:
    drop:
      - ALL
  ```
