### PR TITLE
docs(health-checks): update known issues for health checks

### DIFF
--- a/content/docs/guides/health_checks/health_probes.md
+++ b/content/docs/guides/health_checks/health_probes.md
@@ -427,7 +427,7 @@ server: envoy
 
 ## Known issues
 
-- [#2207](https://github.com/openservicemesh/osm/issues/2207)
+- [#4434](https://github.com/openservicemesh/osm/issues/4434)
 
 ## Troubleshooting
 


### PR DESCRIPTION
Adds a reference to the known tcpSocket probe issue. [#4434](https://github.com/openservicemesh/osm/issues/4434)

I propose backporting this change to v1

Signed-off-by: jaellio <jaellio@microsoft.com>