### PR TITLE
docs: update minimum required k8s version to v1.20.0

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -85,6 +85,7 @@ project_home = "https://openservicemesh.io/"
 osm_branch = "main"
 osm_version = "v0.11.0"
 envoy_version = "v1.19.3"
+min_k8s_version = "v1.20.0"
 
 [[params.versions]]
   version = "v1.0 (latest)"

--- a/content/docs/demos/canary_rollout.md
+++ b/content/docs/demos/canary_rollout.md
@@ -10,7 +10,7 @@ This guide demonstrates how to perform Canary rollouts using the SMI Traffic Spl
 
 ## Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater.
 - Have OSM installed.
 - Have `kubectl` available to interact with the API server.
 - Have `osm` CLI available for managing the service mesh.

--- a/content/docs/demos/cert-manager_integration.md
+++ b/content/docs/demos/cert-manager_integration.md
@@ -9,7 +9,7 @@ This guide demonstrates the usage of [cert-manager][1] as a certificate provider
 
 ## Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater.
 - Have `kubectl` available to interact with the API server.
 - Have `osm` CLI available for installing and managing the service mesh.
 

--- a/content/docs/demos/circuit_breaking_mesh_external.md
+++ b/content/docs/demos/circuit_breaking_mesh_external.md
@@ -9,7 +9,7 @@ This guide demonstrates how to configure circuit breaking for destinations that 
 
 ## Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater.
 - Have OSM installed.
 - Have `kubectl` available to interact with the API server.
 - Have `osm` CLI available for managing the service mesh.

--- a/content/docs/demos/circuit_breaking_mesh_internal.md
+++ b/content/docs/demos/circuit_breaking_mesh_internal.md
@@ -9,7 +9,7 @@ This guide demonstrates how to configure circuit breaking for destinations that 
 
 ## Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater.
 - Have OSM installed.
 - Have `kubectl` available to interact with the API server.
 - Have `osm` CLI available for managing the service mesh.

--- a/content/docs/demos/egress_passthrough.md
+++ b/content/docs/demos/egress_passthrough.md
@@ -10,7 +10,7 @@ This guide demonstrates a client within the service mesh accessing destinations 
 
 ## Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater.
 - Have OSM installed.
 - Have `kubectl` available to interact with the API server.
 - Have `osm` CLI available for managing the service mesh.

--- a/content/docs/demos/egress_policy.md
+++ b/content/docs/demos/egress_policy.md
@@ -10,7 +10,7 @@ This guide demonstrates a client within the service mesh accessing destinations 
 
 ## Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater.
 - Have OSM installed.
 - Have `kubectl` available to interact with the API server.
 - Have `osm` CLI available for managing the service mesh.

--- a/content/docs/demos/ingress_contour.md
+++ b/content/docs/demos/ingress_contour.md
@@ -10,7 +10,7 @@ OSM provides the option to use [Contour](https://projectcontour.io) ingress cont
 
 ## Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater.
 - Have `kubectl` available to interact with the API server.
 - No existing installation of OSM. Any existing installation must first be uninstalled prior to proceeding with this demo.
 - Have `osm` or `Helm 3` CLI available for installing OSM and Contour.

--- a/content/docs/demos/ingress_k8s_nginx.md
+++ b/content/docs/demos/ingress_k8s_nginx.md
@@ -10,7 +10,7 @@ This guide will demonstrate how to configure HTTP and HTTPS ingress to a service
 
 ## Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater.
 - Have `kubectl` available to interact with the API server.
 - Have OSM version >= v0.10.0 installed.
 - Have Kubernetes Nginx Ingress Controller installed. Refer to the [deployment guide](https://kubernetes.github.io/ingress-nginx/deploy/) to install it.

--- a/content/docs/demos/outbound_ip_exclusion.md
+++ b/content/docs/demos/outbound_ip_exclusion.md
@@ -9,7 +9,7 @@ This guide demonstrates how outbound IP address ranges can be excluded from bein
 
 ## Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater.
 - Have OSM installed.
 - Have `kubectl` available to interact with the API server.
 - Have `osm` CLI available for managing the service mesh.

--- a/content/docs/demos/permissive_traffic_mode.md
+++ b/content/docs/demos/permissive_traffic_mode.md
@@ -10,7 +10,7 @@ This guide demonstrates a client and server application within the service mesh 
 
 ## Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater.
 - Have OSM installed.
 - Have `kubectl` available to interact with the API server.
 - Have `osm` CLI available for managing the service mesh.

--- a/content/docs/demos/prometheus_grafana.md
+++ b/content/docs/demos/prometheus_grafana.md
@@ -13,7 +13,7 @@ The following article shows you how to create an example bring your own (BYO) Pr
 
 ## Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater.
 - OSM installed on the Kubernetes cluster.
 - `kubectl` installed and access to the cluster's API server.
 - `osm` CLI installed.

--- a/content/docs/demos/tcp_traffic_routing.md
+++ b/content/docs/demos/tcp_traffic_routing.md
@@ -10,7 +10,7 @@ This guide demonstrates a TCP client and server application within the service m
 
 ## Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.19.0 or greater.
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater.
 - Have OSM installed.
 - Have `kubectl` available to interact with the API server.
 - Have `osm` CLI available for managing the service mesh.

--- a/content/docs/guides/cli.md
+++ b/content/docs/guides/cli.md
@@ -7,7 +7,7 @@ weight: 1
 
 ## Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.19.0 or greater
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater
 
 ## Set up the OSM CLI
 

--- a/content/docs/guides/install.md
+++ b/content/docs/guides/install.md
@@ -7,7 +7,7 @@ weight: 2
 
 ## Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.19.0 or greater
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater
 - The [osm CLI](/docs/guides/cli) or the [helm 3 CLI](https://helm.sh/docs/intro/install/) or the OpenShift `oc` CLI.
 
 ### Kubernetes support


### PR DESCRIPTION
Updates the minimum required k8s version to v.20.0
to reflect the change made by commit 97c6395b in
as a part of openservicemesh/osm#4610.
