### PR TITLE
inline port-forward scripts in demo

### DIFF
--- a/content/docs/getting_started/install_apps.md
+++ b/content/docs/getting_started/install_apps.md
@@ -105,19 +105,30 @@ In addition, a [Kubernetes Service Account](https://kubernetes.io/docs/tasks/con
 
 ### View the Application UIs
 
-Set up client port forwarding with the following steps to access the applications in the Kubernetes cluster. It is best to start a new terminal session for running the port forwarding script to maintain the port forwarding session, while using the original terminal to continue to issue commands. The port-forward-all.sh script will look for a `.env` file for environment variables needed to run the script. The `.env` creates the necessary variables that target the previously created namespaces. We will use the reference `.env.example` file and then run the port forwarding script.
+Set up client port forwarding with the following steps to access the applications in the Kubernetes cluster. It is best to start a new terminal session for running the port forwarding scripts to maintain the port forwarding session, while using the original terminal to continue to issue commands. The port-forward scripts will look for a `.env` file for environment variables needed to run the script. The `.env` creates the necessary variables that target the previously created namespaces. We will use the reference `.env.example` file and then run the port forwarding scripts.
 
 In a new terminal session, run the following commands to enable port forwarding into the Kubernetes cluster from the root of the project directory (your local clone of [upstream OSM](https://github.com/openservicemesh/osm)).
 
 ```bash
 cp .env.example .env
-./scripts/port-forward-all.sh
+bash <<EOF
+./scripts/port-forward-bookbuyer-ui.sh &
+./scripts/port-forward-bookstore-ui.sh &
+./scripts/port-forward-bookthief-ui.sh &
+wait
+EOF
 ```
 
-_Note: To override the default ports, prefix the `BOOKBUYER_LOCAL_PORT`, `BOOKSTORE_LOCAL_PORT`, `BOOKSTOREv1_LOCAL_PORT`, `BOOKSTOREv2_LOCAL_PORT`, and/or `BOOKTHIEF_LOCAL_PORT` variable assignments to the `port-forward` scripts. For example:_
+_Note: To override the default ports, prefix the `BOOKBUYER_LOCAL_PORT`, `BOOKSTORE_LOCAL_PORT`, and/or `BOOKTHIEF_LOCAL_PORT` variable assignments to the `port-forward` scripts. For example:_
 
 ```bash
-BOOKBUYER_LOCAL_PORT=7070 BOOKSTOREv1_LOCAL_PORT=7071 BOOKSTOREv2_LOCAL_PORT=7072 BOOKTHIEF_LOCAL_PORT=7073 BOOKSTORE_LOCAL_PORT=7074 ./scripts/port-forward-all.sh
+export BOOKBUYER_LOCAL_PORT=7070 BOOKTHIEF_LOCAL_PORT=7073 BOOKSTORE_LOCAL_PORT=7074
+bash <<EOF
+./scripts/port-forward-bookbuyer-ui.sh &
+./scripts/port-forward-bookstore-ui.sh &
+./scripts/port-forward-bookthief-ui.sh &
+wait
+EOF
 ```
 
 In a browser, open up the following urls:
@@ -125,10 +136,8 @@ In a browser, open up the following urls:
 - [http://localhost:8080](http://localhost:8080) - **bookbuyer**
 - [http://localhost:8083](http://localhost:8083) - **bookthief**
 - [http://localhost:8084](http://localhost:8084) - **bookstore**
-- [http://localhost:8082](http://localhost:8082) - **bookstore-v2**
-  - _Note: This page will not be available at this time in the demo. This will become available during the SMI Traffic Split configuration set up_
 
-Position the windows so that you can see all four at the same time. The header at the top of the webpage indicates the application and version.
+Position the windows so that you can see all of them at the same time. The header at the top of the webpage indicates the application and version.
 
 ## Next Steps
 

--- a/content/docs/getting_started/observability.md
+++ b/content/docs/getting_started/observability.md
@@ -47,8 +47,6 @@ The OSM Grafana dashboards can be viewed with the following command:
 osm dashboard
 ```
 
-> Note: If you still have the additional terminal still running the `./scripts/port-forward-all.sh` script, go ahead and `CTRL+C` to terminate the port forwarding. The `osm dashboard` port redirection will not work simultaneously with the port forwarding script still running.
-
 Navigate to http://localhost:3000 to access the Grafana dashboards. The default user name is `admin` and the default password is `admin`. On the Grafana homepage click on the **Home** icon, you will see a folder containing dashboards for both OSM Control Plane and OSM Data Plane.
 
 ## Next Steps

--- a/content/docs/getting_started/traffic_split.md
+++ b/content/docs/getting_started/traffic_split.md
@@ -19,7 +19,17 @@ To demonstrate usage of SMI traffic access and split policies, we will now deplo
 kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/apps/bookstore-v2.yaml
 ```
 
-Wait for the `bookstore-v2` pod to be running in the `bookstore` namespace. Next, exit and restart the `./scripts/port-forward-all.sh` script in order to access v2 of bookstore.
+Wait for the `bookstore-v2` pod to be running in the `bookstore` namespace. Next, exit and restart the port-forward scripts in order to access v2 of bookstore:
+
+```bash
+bash <<EOF
+./scripts/port-forward-bookbuyer-ui.sh &
+./scripts/port-forward-bookstore-ui.sh &
+./scripts/port-forward-bookstore-ui-v2.sh &
+./scripts/port-forward-bookthief-ui.sh &
+wait
+EOF
+```
 
 - [http://localhost:8082](http://localhost:8082) - **bookstore-v2**
 


### PR DESCRIPTION
The existing port-forward-all.sh script in the code repo forwards ports
for the demo described here and the automated demo defined in the code
repo. The automated demo defines a `bookstore-v1` deployment where the
demo here names it only `bookstore`, both of which are port-forwarded by
the script, which then throws nondescript messages related to either one
of those not existing when running either demo.

These changes inline the specific scripts needed at each point in the
demo to ensure only components that are expected to exist have ports
forwarded so no error messages are expected.

Part of https://github.com/openservicemesh/osm/issues/3521