### PR TITLE
tsg: remove duplicate table of contents

### DIFF
--- a/content/docs/guides/troubleshooting/traffic_management/_index.md
+++ b/content/docs/guides/troubleshooting/traffic_management/_index.md
@@ -3,8 +3,3 @@ title: "Traffic"
 description: "Troubleshooting traffic problems"
 type: docs
 ---
-
-## Table of Contents
-- [Iptables redirection troubleshooting](/docs/guides/traffic_management/troubleshooting/iptables_redirection)
-- [Egress troubleshooting](/docs/guides/traffic_management/troubleshooting/egress)
-- [Permissive traffic policy mode troubleshooting](/docs/guides/traffic_management/troubleshooting/permissive_traffic_policy_mode)


### PR DESCRIPTION
index.md auto renders the table of contents,
remove redundant table.
