### PR TITLE
docs: fix prerequisites of osm v1.1.x

### DIFF
--- a/content/docs/getting_started/setup_osm.md
+++ b/content/docs/getting_started/setup_osm.md
@@ -9,7 +9,7 @@ weight: 1
 
 ## Prerequisites
 This demo of OSM {{< param osm_version >}} requires:
-  - a cluster running Kubernetes v1.19 or greater (using a cloud provider of choice, [minikube](https://minikube.sigs.k8s.io/docs/start/), or similar)
+  - a cluster running Kubernetes v1.20 or greater (using a cloud provider of choice, [minikube](https://minikube.sigs.k8s.io/docs/start/), or similar)
   - a workstation capable of executing [Bash](https://en.wikipedia.org/wiki/Bash_(Unix_shell)) scripts
   - [The Kubernetes command-line tool](https://kubernetes.io/docs/tasks/tools/#kubectl) - `kubectl`
   - the [OSM code repo](https://github.com/openservicemesh/osm/) available locally


### PR DESCRIPTION
It needs k8s v1.20 or greater for osm v1.1.x

Signed-off-by: Lin Yang <reaver@flomesh.io>