### PR TITLE
docs: add local rate limiting guide and demo

### DIFF
--- a/content/docs/api_reference/policy/v1alpha1.md
+++ b/content/docs/api_reference/policy/v1alpha1.md
@@ -469,6 +469,208 @@ Defaults to 4294967295 (2^32 - 1) if not specified.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="policy.openservicemesh.io/v1alpha1.HTTPHeaderValue">HTTPHeaderValue
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.HTTPLocalRateLimitSpec">HTTPLocalRateLimitSpec</a>)
+</p>
+<p>
+<p>HTTPHeaderValue defines an HTTP header name/value pair</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name defines the name of the HTTP header.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Value defines the value of the header corresponding to the name key.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.HTTPLocalRateLimitSpec">HTTPLocalRateLimitSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.HTTPPerRouteRateLimitSpec">HTTPPerRouteRateLimitSpec</a>, <a href="#policy.openservicemesh.io/v1alpha1.LocalRateLimitSpec">LocalRateLimitSpec</a>)
+</p>
+<p>
+<p>HTTPLocalRateLimitSpec defines the local rate limiting specification
+for the upstream host at the HTTP level.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>requests</code><br/>
+<em>
+uint32
+</em>
+</td>
+<td>
+<p>Requests defines the number of requests allowed
+per unit of time before rate limiting occurs.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>unit</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Unit defines the period of time within which requests
+over the limit will be rate limited.
+Valid values are &ldquo;second&rdquo;, &ldquo;minute&rdquo; and &ldquo;hour&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>burst</code><br/>
+<em>
+uint32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Burst defines the number of requests above the baseline
+rate that are allowed in a short period of time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>responseStatusCode</code><br/>
+<em>
+uint32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResponseStatusCode defines the HTTP status code to use for responses
+to rate limited requests. Code must be in the 400-599 (inclusive)
+error range. If not specified, a default of 429 (Too Many Requests) is used.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>responseHeadersToAdd</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.HTTPHeaderValue">
+[]HTTPHeaderValue
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResponseHeadersToAdd defines the list of HTTP headers that should be
+added to each response for requests that have been rate limited.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.HTTPPerRouteRateLimitSpec">HTTPPerRouteRateLimitSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.HTTPRouteSpec">HTTPRouteSpec</a>)
+</p>
+<p>
+<p>HTTPPerRouteRateLimitSpec defines the rate limiting specification
+per HTTP route.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>local</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.HTTPLocalRateLimitSpec">
+HTTPLocalRateLimitSpec
+</a>
+</em>
+</td>
+<td>
+<p>Local defines the local rate limiting specification
+applied per HTTP route.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.HTTPRouteSpec">HTTPRouteSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.UpstreamTrafficSettingSpec">UpstreamTrafficSettingSpec</a>)
+</p>
+<p>
+<p>HTTPRouteSpec defines the settings correspondng to an HTTP route</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>path</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Path defines the HTTP path.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>rateLimit</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.HTTPPerRouteRateLimitSpec">
+HTTPPerRouteRateLimitSpec
+</a>
+</em>
+</td>
+<td>
+<p>RateLimit defines the HTTP rate limiting specification for
+the specified HTTP route.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="policy.openservicemesh.io/v1alpha1.IngressBackend">IngressBackend
 </h3>
 <p>
@@ -728,6 +930,60 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="policy.openservicemesh.io/v1alpha1.LocalRateLimitSpec">LocalRateLimitSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.RateLimitSpec">RateLimitSpec</a>)
+</p>
+<p>
+<p>LocalRateLimitSpec defines the local rate limiting specification
+for the upstream host.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>tcp</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.TCPLocalRateLimitSpec">
+TCPLocalRateLimitSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TCP defines the local rate limiting specification at the network
+level. This is a token bucket rate limiter where each connection
+consumes a single token. If the token is available, the connection
+will be allowed. If no tokens are available, the connection will be
+immediately closed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>http</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.HTTPLocalRateLimitSpec">
+HTTPLocalRateLimitSpec
+</a>
+</em>
+</td>
+<td>
+<p>HTTP defines the local rate limiting specification for HTTP traffic.
+This is a token bucket rate limiter where each request consumes
+a single token. If the token is available, the request will be
+allowed. If no tokens are available, the request will receive the
+configured rate limit status.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="policy.openservicemesh.io/v1alpha1.PortSpec">PortSpec
 </h3>
 <p>
@@ -764,6 +1020,43 @@ string
 </td>
 <td>
 <p>Protocol defines the protocol served by the port.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.RateLimitSpec">RateLimitSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.UpstreamTrafficSettingSpec">UpstreamTrafficSettingSpec</a>)
+</p>
+<p>
+<p>RateLimitSpec defines the rate limiting specification for
+the upstream host.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>local</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.LocalRateLimitSpec">
+LocalRateLimitSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Local specified the local rate limiting specification
+for the upstream host.
+Local rate limiting is enforced directly by the upstream
+host without any involvement of a global rate limiting service.
+This is applied as a token bucket rate limiter.</p>
 </td>
 </tr>
 </tbody>
@@ -889,10 +1182,13 @@ string
 <td>
 <code>perTryTimeout</code><br/>
 <em>
-string
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>PerTryTimeout defines the time allowed for a retry before it&rsquo;s considered a failed attempt.</p>
 </td>
 </tr>
@@ -900,21 +1196,25 @@ string
 <td>
 <code>numRetries</code><br/>
 <em>
-int
+uint32
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>NumRetries defines the max number of retries to attempt.</p>
 </td>
 </tr>
 <tr>
 <td>
-<code>retryBackoffInterval</code><br/>
+<code>retryBackoffBaseInterval</code><br/>
 <em>
-string
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>RetryBackoffBaseInterval defines the base interval for exponential retry backoff.</p>
 </td>
 </tr>
@@ -1077,6 +1377,63 @@ Defaults to 5s if not specified.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="policy.openservicemesh.io/v1alpha1.TCPLocalRateLimitSpec">TCPLocalRateLimitSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.LocalRateLimitSpec">LocalRateLimitSpec</a>)
+</p>
+<p>
+<p>TCPLocalRateLimitSpec defines the local rate limiting specification
+for the upstream host at the TCP level.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>connections</code><br/>
+<em>
+uint32
+</em>
+</td>
+<td>
+<p>Connections defines the number of connections allowed
+per unit of time before rate limiting occurs.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>unit</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Unit defines the period of time within which connections
+over the limit will be rate limited.
+Valid values are &ldquo;second&rdquo;, &ldquo;minute&rdquo; and &ldquo;hour&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>burst</code><br/>
+<em>
+uint32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Burst defines the number of connections above the baseline
+rate that are allowed in a short period of time.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="policy.openservicemesh.io/v1alpha1.TLSSpec">TLSSpec
 </h3>
 <p>
@@ -1196,6 +1553,43 @@ directed to the upstream host.</p>
 </tr>
 <tr>
 <td>
+<code>rateLimit</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.RateLimitSpec">
+RateLimitSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RateLimit specifies the rate limit settings for the traffic
+directed to the upstream host.
+If HTTP rate limiting is specified, the rate limiting is applied
+at the VirtualHost level applicable to all routes within the
+VirtualHost.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>httpRoutes</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.HTTPRouteSpec">
+[]HTTPRouteSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>HTTPRoutes defines the list of HTTP routes settings
+for the upstream host. Settings are applied at a per
+route level.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
 <code>status</code><br/>
 <em>
 <a href="#policy.openservicemesh.io/v1alpha1.UpstreamTrafficSettingStatus">
@@ -1206,9 +1600,6 @@ UpstreamTrafficSettingStatus
 <td>
 <em>(Optional)</em>
 <p>Status is the status of the UpstreamTrafficSetting resource.</p>
-</td>
-</tr>
-</table>
 </td>
 </tr>
 </tbody>
@@ -1261,16 +1652,36 @@ directed to the upstream host.</p>
 </tr>
 <tr>
 <td>
-<code>status</code><br/>
+<code>rateLimit</code><br/>
 <em>
-<a href="#policy.openservicemesh.io/v1alpha1.UpstreamTrafficSettingStatus">
-UpstreamTrafficSettingStatus
+<a href="#policy.openservicemesh.io/v1alpha1.RateLimitSpec">
+RateLimitSpec
 </a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Status is the status of the UpstreamTrafficSetting resource.</p>
+<p>RateLimit specifies the rate limit settings for the traffic
+directed to the upstream host.
+If HTTP rate limiting is specified, the rate limiting is applied
+at the VirtualHost level applicable to all routes within the
+VirtualHost.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>httpRoutes</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.HTTPRouteSpec">
+[]HTTPRouteSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>HTTPRoutes defines the list of HTTP routes settings
+for the upstream host. Settings are applied at a per
+route level.</p>
 </td>
 </tr>
 </tbody>
@@ -1278,7 +1689,7 @@ UpstreamTrafficSettingStatus
 <h3 id="policy.openservicemesh.io/v1alpha1.UpstreamTrafficSettingStatus">UpstreamTrafficSettingStatus
 </h3>
 <p>
-(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.UpstreamTrafficSettingSpec">UpstreamTrafficSettingSpec</a>)
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.UpstreamTrafficSetting">UpstreamTrafficSetting</a>)
 </p>
 <p>
 <p>UpstreamTrafficSettingStatus defines the status of an UpstreamTrafficSetting resource.</p>
@@ -1320,5 +1731,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>7e0674c3</code>.
+on git commit <code>a5b37165</code>.
 </em></p>

--- a/content/docs/demos/local_rate_limit_connections.md
+++ b/content/docs/demos/local_rate_limit_connections.md
@@ -102,15 +102,15 @@ The following demo shows a client [fortio-client](https://github.com/fortio/fort
     apiVersion: policy.openservicemesh.io/v1alpha1
     kind: UpstreamTrafficSetting
     metadata:
-    name: tcp-rate-limit
-    namespace: demo
+      name: tcp-rate-limit
+      namespace: demo
     spec:
-    host: fortio.demo.svc.cluster.local
-    rateLimit:
-    local:
-        tcp:
-        connections: 1
-        unit: minute
+      host: fortio.demo.svc.cluster.local
+      rateLimit:
+        local:
+          tcp:
+            connections: 1
+            unit: minute
     EOF
     ```
 

--- a/content/docs/demos/local_rate_limit_connections.md
+++ b/content/docs/demos/local_rate_limit_connections.md
@@ -172,7 +172,7 @@ The following demo shows a client [fortio-client](https://github.com/fortio/fort
 
     Examine the sidecar stats to further confirm this.
     ```console
-    $ osm proxy get stats "$fortio_server" -n demo | grep fortio.*8078.*rate_limit
+    $ osm proxy get stats "$fortio_server" -n demo | grep 'fortio.*8078.*rate_limit'
     local_rate_limit.inbound_demo/fortio_8078_tcp.rate_limited: 7
     ```
 
@@ -182,13 +182,13 @@ The following demo shows a client [fortio-client](https://github.com/fortio/fort
     apiVersion: policy.openservicemesh.io/v1alpha1
     kind: UpstreamTrafficSetting
     metadata:
-    name: tcp-echo-limit
-    namespace: demo
+      name: tcp-echo-limit
+      namespace: demo
     spec:
-    host: fortio.demo.svc.cluster.local
-    rateLimit:
+      host: fortio.demo.svc.cluster.local
+      rateLimit:
         local:
-        tcp:
+          tcp:
             connections: 1
             unit: minute
             burst: 10
@@ -231,6 +231,6 @@ The following demo shows a client [fortio-client](https://github.com/fortio/fort
 
     Further, examine the stats to confirm the burst allows additional connections to go through. The number of connections rate limited hasn't increased since our previous rate limit test before we configured the burst setting.
     ```console
-    $ osm proxy get stats "$fortio_server" -n demo | grep fortio.*8078.*rate_limit
+    $ osm proxy get stats "$fortio_server" -n demo | grep 'fortio.*8078.*rate_limit'
     local_rate_limit.inbound_demo/fortio_8078_tcp.rate_limited: 7
     ```

--- a/content/docs/demos/local_rate_limit_connections.md
+++ b/content/docs/demos/local_rate_limit_connections.md
@@ -1,0 +1,236 @@
+---
+title: "Local rate limiting of L4 connections"
+description: "Configuring local rate limiting for L4 connections"
+type: docs
+weight: 22
+---
+
+This guide demonstrates how to configure rate limiting for L4 TCP connections destined to a target host that is a part of an OSM managed service mesh.
+
+## Prerequisites
+
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater.
+- Have OSM installed.
+- Have `kubectl` available to interact with the API server.
+- Have `osm` CLI available for managing the service mesh.
+- OSM version >= v1.2.0.
+
+
+## Demo
+
+The following demo shows a client [fortio-client](https://github.com/fortio/fortio) sending TCP traffic to the `fortio` `TCP echo` service. The `fortio` service echoes TCP messages back to the client. We will see the impact of applying local TCP rate limiting policies targeting the `fortio` service to control the throughput of traffic destined to the service backend.
+
+1. For simplicity, enable [permissive traffic policy mode](/docs/guides/traffic_management/permissive_mode) so that explicit SMI traffic access policies are not required for application connectivity within the mesh.
+    ```bash
+    export osm_namespace=osm-system # Replace osm-system with the namespace where OSM is installed
+    kubectl patch meshconfig osm-mesh-config -n "$osm_namespace" -p '{"spec":{"traffic":{"enablePermissiveTrafficPolicyMode":true}}}'  --type=merge
+    ```
+
+1. Deploy the `fortio` `TCP echo` service in the `demo` namespace after enrolling its namespace to the mesh. The `fortio` `TCP echo` service runs on port `8078`.
+    ```bash
+    # Create the demo namespace
+    kubectl create namespace demo
+
+    # Add the namespace to the mesh
+    osm namespace add demo
+
+    # Deploy fortio TCP echo in the demo namespace
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/fortio/fortio.yaml -n demo
+    ```
+
+    Confirm the `fortio` service pod is up and running.
+
+    ```console
+    $ kubectl get pods -n demo
+    NAME                            READY   STATUS    RESTARTS   AGE
+    fortio-c4bd7857f-7mm6w          2/2     Running   0          22m
+    ```
+
+1. Deploy the `fortio-client` app in the `demo` namespace. We will use this client to send TCP traffic to the `fortio TCP echo` service deployed previously.
+    ```bash
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/fortio/fortio-client.yaml -n demo
+    ```
+
+    Confirm the `fortio-client` pod is up and running.
+
+    ```console
+    NAME                            READY   STATUS    RESTARTS   AGE
+    fortio-client-b9b7bbfb8-prq7r   2/2     Running   0          7s
+    ```
+
+1. Confirm the `fortio-client` app is able to successfully make TCP connections and send data to the `frotio` `TCP echo` service on port `8078`. We call the `fortio` service with `3` concurrent connections (`-c 3`) and send `10` calls (`-n 10`).
+    ```console
+    $ fortio_client="$(kubectl get pod -n demo -l app=fortio-client -o jsonpath='{.items[0].metadata.name}')"
+
+    $ $ kubectl exec "$fortio_client" -n demo -c fortio-client -- fortio load -qps -1 -c 3 -n 10 tcp://fortio.demo.svc.cluster.local:8078
+    Fortio 1.32.3 running at -1 queries per second, 8->8 procs, for 10 calls: tcp://fortio.demo.svc.cluster.local:8078
+    20:41:47 I tcprunner.go:238> Starting tcp test for tcp://fortio.demo.svc.cluster.local:8078 with 3 threads at -1.0 qps
+    Starting at max qps with 3 thread(s) [gomax 8] for exactly 10 calls (3 per thread + 1)
+    20:41:47 I periodic.go:723> T001 ended after 34.0563ms : 3 calls. qps=88.0894283876992
+    20:41:47 I periodic.go:723> T000 ended after 35.3117ms : 4 calls. qps=113.2769025563765
+    20:41:47 I periodic.go:723> T002 ended after 44.0273ms : 3 calls. qps=68.13954069406937
+    Ended after 44.2097ms : 10 calls. qps=226.19
+    Aggregated Function Time : count 10 avg 0.01096615 +/- 0.01386 min 0.001588 max 0.0386716 sum 0.1096615
+    # range, mid point, percentile, count
+    >= 0.001588 <= 0.002 , 0.001794 , 40.00, 4
+    > 0.002 <= 0.003 , 0.0025 , 60.00, 2
+    > 0.003 <= 0.004 , 0.0035 , 70.00, 1
+    > 0.025 <= 0.03 , 0.0275 , 90.00, 2
+    > 0.035 <= 0.0386716 , 0.0368358 , 100.00, 1
+    # target 50% 0.0025
+    # target 75% 0.02625
+    # target 90% 0.03
+    # target 99% 0.0383044
+    # target 99.9% 0.0386349
+    Error cases : no data
+    Sockets used: 3 (for perfect no error run, would be 3)
+    Total Bytes sent: 240, received: 240
+    tcp OK : 10 (100.0 %)
+    All done 10 calls (plus 0 warmup) 10.966 ms avg, 226.2 qps
+    ```
+
+    As seen above, all the TCP connections from the `fortio-client` pod succeeded.
+    ```
+    Total Bytes sent: 240, received: 240
+    tcp OK : 10 (100.0 %)
+    All done 10 calls (plus 0 warmup) 10.966 ms avg, 226.2 qps
+    ```
+
+1. Next, apply a local rate limiting policy to rate limit L4 TCP connections to the `fortio.demo.svc.cluster.local` service to `1 connection per minute`.
+    ```bash
+    kubectl apply -f - <<EOF
+    apiVersion: policy.openservicemesh.io/v1alpha1
+    kind: UpstreamTrafficSetting
+    metadata:
+    name: tcp-rate-limit
+    namespace: demo
+    spec:
+    host: fortio.demo.svc.cluster.local
+    rateLimit:
+    local:
+        tcp:
+        connections: 1
+        unit: minute
+    EOF
+    ```
+
+    Confirm no traffic has been rate limited yet by examining the stats on the `fortio` backend pod.
+    ```console
+    $ fortio_server="$(kubectl get pod -n demo -l app=fortio -o jsonpath='{.items[0].metadata.name}')"
+
+    $ osm proxy get stats "$fortio_server" -n demo | grep fortio.*8078.*rate_limit
+    local_rate_limit.inbound_demo/fortio_8078_tcp.rate_limited: 0
+    ```
+
+1. Confirm TCP connections are rate limited.
+    ```console
+    $ kubectl exec "$fortio_client" -n demo -c fortio-client -- fortio load -qps -1 -c 3 -n 10 tcp://fortio.demo.svc.cluster.local:8078
+    Fortio 1.32.3 running at -1 queries per second, 8->8 procs, for 10 calls: tcp://fortio.demo.svc.cluster.local:8078
+    20:49:38 I tcprunner.go:238> Starting tcp test for tcp://fortio.demo.svc.cluster.local:8078 with 3 threads at -1.0 qps
+    Starting at max qps with 3 thread(s) [gomax 8] for exactly 10 calls (3 per thread + 1)
+    20:49:38 E tcprunner.go:203> [2] Unable to read: read tcp 10.244.1.19:59244->10.96.83.254:8078: read: connection reset by peer
+    20:49:38 E tcprunner.go:203> [0] Unable to read: read tcp 10.244.1.19:59246->10.96.83.254:8078: read: connection reset by peer
+    20:49:38 E tcprunner.go:203> [2] Unable to read: read tcp 10.244.1.19:59258->10.96.83.254:8078: read: connection reset by peer
+    20:49:38 E tcprunner.go:203> [0] Unable to read: read tcp 10.244.1.19:59260->10.96.83.254:8078: read: connection reset by peer
+    20:49:38 E tcprunner.go:203> [2] Unable to read: read tcp 10.244.1.19:59266->10.96.83.254:8078: read: connection reset by peer
+    20:49:38 I periodic.go:723> T002 ended after 9.643ms : 3 calls. qps=311.1065021258944
+    20:49:38 E tcprunner.go:203> [0] Unable to read: read tcp 10.244.1.19:59268->10.96.83.254:8078: read: connection reset by peer
+    20:49:38 E tcprunner.go:203> [0] Unable to read: read tcp 10.244.1.19:59274->10.96.83.254:8078: read: connection reset by peer
+    20:49:38 I periodic.go:723> T000 ended after 14.8212ms : 4 calls. qps=269.8836801338623
+    20:49:38 I periodic.go:723> T001 ended after 20.3458ms : 3 calls. qps=147.45057948077735
+    Ended after 20.5468ms : 10 calls. qps=486.69
+    Aggregated Function Time : count 10 avg 0.00438853 +/- 0.004332 min 0.0014184 max 0.0170216 sum 0.0438853
+    # range, mid point, percentile, count
+    >= 0.0014184 <= 0.002 , 0.0017092 , 20.00, 2
+    > 0.002 <= 0.003 , 0.0025 , 50.00, 3
+    > 0.003 <= 0.004 , 0.0035 , 70.00, 2
+    > 0.004 <= 0.005 , 0.0045 , 90.00, 2
+    > 0.016 <= 0.0170216 , 0.0165108 , 100.00, 1
+    # target 50% 0.003
+    # target 75% 0.00425
+    # target 90% 0.005
+    # target 99% 0.0169194
+    # target 99.9% 0.0170114
+    Error cases : count 7 avg 0.0034268714 +/- 0.0007688 min 0.0024396 max 0.0047932 sum 0.0239881
+    # range, mid point, percentile, count
+    >= 0.0024396 <= 0.003 , 0.0027198 , 42.86, 3
+    > 0.003 <= 0.004 , 0.0035 , 71.43, 2
+    > 0.004 <= 0.0047932 , 0.0043966 , 100.00, 2
+    # target 50% 0.00325
+    # target 75% 0.00409915
+    # target 90% 0.00451558
+    # target 99% 0.00476544
+    # target 99.9% 0.00479042
+    Sockets used: 8 (for perfect no error run, would be 3)
+    Total Bytes sent: 240, received: 72
+    tcp OK : 3 (30.0 %)
+    tcp short read : 7 (70.0 %)
+    All done 10 calls (plus 0 warmup) 4.389 ms avg, 486.7 qps
+    ```
+
+    As seen above, only 30% of the 10 calls succeeded, while the remaining 70% was rate limitied. This is because we applied a rate limiting policy of 1 connection per minute at the `fortio` backend service, and the `fortio-client` was able to use 1 connection to make 3/10 calls, resulting in a 30% success rate.
+
+    Examine the sidecar stats to further confirm this.
+    ```console
+    $ osm proxy get stats "$fortio_server" -n demo | grep fortio.*8078.*rate_limit
+    local_rate_limit.inbound_demo/fortio_8078_tcp.rate_limited: 7
+    ```
+
+1. Next, let's update our rate limiting policy to allow a burst of connections. Bursts allow a given number of connections over the baseline rate of 1 connection per minute defined by our rate limiting policy.
+    ```bash
+    kubectl apply -f - <<EOF
+    apiVersion: policy.openservicemesh.io/v1alpha1
+    kind: UpstreamTrafficSetting
+    metadata:
+    name: tcp-echo-limit
+    namespace: demo
+    spec:
+    host: fortio.demo.svc.cluster.local
+    rateLimit:
+        local:
+        tcp:
+            connections: 1
+            unit: minute
+            burst: 10
+    EOF
+    ```
+
+1. Confirm the burst capability allows a burst of connections within a small window of time.
+    ```console
+    $ kubectl exec "$fortio_client" -n demo -c fortio-client -- fortio load -qps -1 -c 3 -n 10 tcp://fortio.demo.svc.cluster.local:8078
+    Fortio 1.32.3 running at -1 queries per second, 8->8 procs, for 10 calls: tcp://fortio.demo.svc.cluster.local:8078
+    20:56:56 I tcprunner.go:238> Starting tcp test for tcp://fortio.demo.svc.cluster.local:8078 with 3 threads at -1.0 qps
+    Starting at max qps with 3 thread(s) [gomax 8] for exactly 10 calls (3 per thread + 1)
+    20:56:56 I periodic.go:723> T002 ended after 5.1568ms : 3 calls. qps=581.7561278312132
+    20:56:56 I periodic.go:723> T001 ended after 5.2334ms : 3 calls. qps=573.2411052088509
+    20:56:56 I periodic.go:723> T000 ended after 5.2464ms : 4 calls. qps=762.4275693809088
+    Ended after 5.2711ms : 10 calls. qps=1897.1
+    Aggregated Function Time : count 10 avg 0.00153124 +/- 0.001713 min 0.00033 max 0.0044054 sum 0.0153124
+    # range, mid point, percentile, count
+    >= 0.00033 <= 0.001 , 0.000665 , 70.00, 7
+    > 0.003 <= 0.004 , 0.0035 , 80.00, 1
+    > 0.004 <= 0.0044054 , 0.0042027 , 100.00, 2
+    # target 50% 0.000776667
+    # target 75% 0.0035
+    # target 90% 0.0042027
+    # target 99% 0.00438513
+    # target 99.9% 0.00440337
+    Error cases : no data
+    Sockets used: 3 (for perfect no error run, would be 3)
+    Total Bytes sent: 240, received: 240
+    tcp OK : 10 (100.0 %)
+    All done 10 calls (plus 0 warmup) 1.531 ms avg, 1897.1 qps
+    ```
+
+    As seen above, all the TCP connections from the `fortio-client` pod succeeded.
+    ```
+    Total Bytes sent: 240, received: 240
+    tcp OK : 10 (100.0 %)
+    All done 10 calls (plus 0 warmup) 1.531 ms avg, 1897.1 qps
+    ```
+
+    Further, examine the stats to confirm the burst allows additional connections to go through. The number of connections rate limited hasn't increased since our previous rate limit test before we configured the burst setting.
+    ```console
+    $ osm proxy get stats "$fortio_server" -n demo | grep fortio.*8078.*rate_limit
+    local_rate_limit.inbound_demo/fortio_8078_tcp.rate_limited: 7
+    ```

--- a/content/docs/guides/traffic_management/rate_limiting.md
+++ b/content/docs/guides/traffic_management/rate_limiting.md
@@ -1,0 +1,43 @@
+---
+title: "Rate Limiting"
+description: "Using rircuit breaking to control the throughput of traffic"
+type: docs
+weight: 12
+---
+
+# Rate Limiting
+
+Rate limiting is an effective mechanism to control the throughput of traffic destined to a target host. It puts a cap on how often downstream clients can send network traffic within a certain timeframe.
+
+Most commonly, when a large number of clients are sending traffic to a target host, if the target host becomes backed up, the downstream clients will overwhelm the upstream target host. In this scenario it is extremely difficult to configure a tight enough circuit breaking limit on each downstream host such that the system will operate normally during typical request patterns but still prevent cascading failure when the system starts to fail. In such scenarios, rate limiting traffic to the target host is effective.
+
+OSM support server-side rate limiting per target host, also referred to as `local per-instance rate limiting`.
+
+## Configuring local per-instance rate limiting
+
+OSM leverages its [UpstreamTrafficSetting API][1] to configure rate breaking attributes for traffic directed to an upstream service. We use the term `upstream service` to refer to a service that receives connections and requests from clients and return responses. The specification enables configuring local rate limiting attributes for an upstream service at the connection and request level. OSM leverages [Envoy's local rate limiting functionality](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/local_rate_limit_filter#config-network-filters-local-rate-limit) to implement per-instance local rate limiting at each upstream host.
+
+Each `UpstreamTrafficSetting` configuration targets an upstream host defined by the `spec.host` field. For a Kubernetes service `my-svc` in the namespace `my-namespace`, the `UpstreamTrafficSetting` resource must be created in the namespace `my-namespace`, and `spec.host` must be an FQDN of the form `my-svc.my-namespace.svc.cluster.local`.
+
+Local rate limiting is applicable at both the TCP (L4) connection and HTTP request level, and can be configured using the `rateLimit.local` attribute in the `UpstreamTrafficSetting` resource. TCP settings apply to both TCP and HTTP traffic, while HTTP settings only apply to HTTP traffic. Both TCP and HTTP level rate limiting is enforced using a token bucket rate limiter.
+
+### Rate limiting TCP connections
+
+TCP connections can be rate limited per unit of time. An optional burst limit can be specified to allow a burst of connections above the baseline rate to accommodate for connection bursts in a short interval of time. TCP rate limiting is applied as a token bucket rate limiter at the network filter chain of the upstream service’s inbound listener. Each incoming connection processed by the filter consumes a single token. If the token is available, the connection will be allowed. If no tokens are available, the connection will be immediately closed.
+
+The following attributes nested under `spec.rateLimit.local.tcp` define the rate limiting attributes for TCP connections:
+
+- `Connections`: The number of connections allowed per unit of time before rate limiting occurs on all backends belonging to the upstream host specified via the `spec.host` field in the `UpstreamTrafficSetting` configuration. This setting can be configured using the `connections` field and is applicable to both TCP and HTTP traffic.
+
+- `Unit`: The period of time within which connections over the limit will be rate limited. Valid values are `second`, `minute` and `hour`.
+
+- `Burst`: The number of connections above the baseline rate that are allowed in a short period of time.
+
+Refer to the [TCP local rate limiting API](/docs/api_reference/policy/v1alpha1/#policy.openservicemesh.io/v1alpha1.TCPLocalRateLimitSpec) for additional information regarding API usage.
+
+## Demos
+
+To learn more about configuring rate limting, refer to the following demo guides:
+- [Local rate limiting of TCP connections](/docs/demos/local_rate_limit_connections)
+
+[1]: /docs/api_reference/policy/v1alpha1/#policy.openservicemesh.io/v1alpha1.UpstreamTrafficSettingSpec

--- a/content/docs/guides/traffic_management/rate_limiting.md
+++ b/content/docs/guides/traffic_management/rate_limiting.md
@@ -11,11 +11,11 @@ Rate limiting is an effective mechanism to control the throughput of traffic des
 
 Most commonly, when a large number of clients are sending traffic to a target host, if the target host becomes backed up, the downstream clients will overwhelm the upstream target host. In this scenario it is extremely difficult to configure a tight enough circuit breaking limit on each downstream host such that the system will operate normally during typical request patterns but still prevent cascading failure when the system starts to fail. In such scenarios, rate limiting traffic to the target host is effective.
 
-OSM support server-side rate limiting per target host, also referred to as `local per-instance rate limiting`.
+OSM supports server-side rate limiting per target host, also referred to as `local per-instance rate limiting`.
 
 ## Configuring local per-instance rate limiting
 
-OSM leverages its [UpstreamTrafficSetting API][1] to configure rate breaking attributes for traffic directed to an upstream service. We use the term `upstream service` to refer to a service that receives connections and requests from clients and return responses. The specification enables configuring local rate limiting attributes for an upstream service at the connection and request level. OSM leverages [Envoy's local rate limiting functionality](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/local_rate_limit_filter#config-network-filters-local-rate-limit) to implement per-instance local rate limiting at each upstream host.
+OSM leverages its [UpstreamTrafficSetting API][1] to configure rate limiting attributes for traffic directed to an upstream service. We use the term `upstream service` to refer to a service that receives connections and requests from clients and return responses. The specification enables configuring local rate limiting attributes for an upstream service at the connection and request level. OSM leverages [Envoy's local rate limiting functionality](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/local_rate_limit_filter#config-network-filters-local-rate-limit) to implement per-instance local rate limiting at each upstream host.
 
 Each `UpstreamTrafficSetting` configuration targets an upstream host defined by the `spec.host` field. For a Kubernetes service `my-svc` in the namespace `my-namespace`, the `UpstreamTrafficSetting` resource must be created in the namespace `my-namespace`, and `spec.host` must be an FQDN of the form `my-svc.my-namespace.svc.cluster.local`.
 
@@ -27,11 +27,11 @@ TCP connections can be rate limited per unit of time. An optional burst limit ca
 
 The following attributes nested under `spec.rateLimit.local.tcp` define the rate limiting attributes for TCP connections:
 
-- `Connections`: The number of connections allowed per unit of time before rate limiting occurs on all backends belonging to the upstream host specified via the `spec.host` field in the `UpstreamTrafficSetting` configuration. This setting can be configured using the `connections` field and is applicable to both TCP and HTTP traffic.
+- `connections`: The number of connections allowed per unit of time before rate limiting occurs on all backends belonging to the upstream host specified via the `spec.host` field in the `UpstreamTrafficSetting` configuration. This setting can be configured using the `connections` field and is applicable to both TCP and HTTP traffic.
 
-- `Unit`: The period of time within which connections over the limit will be rate limited. Valid values are `second`, `minute` and `hour`.
+- `unit`: The period of time within which connections over the limit will be rate limited. Valid values are `second`, `minute` and `hour`.
 
-- `Burst`: The number of connections above the baseline rate that are allowed in a short period of time.
+- `burst`: The number of connections above the baseline rate that are allowed in a short period of time.
 
 Refer to the [TCP local rate limiting API](/docs/api_reference/policy/v1alpha1/#policy.openservicemesh.io/v1alpha1.TCPLocalRateLimitSpec) for additional information regarding API usage.
 

--- a/manifests/samples/fortio/fortio-client.yaml
+++ b/manifests/samples/fortio/fortio-client.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fortio-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fortio-client
+  template:
+    metadata:
+      labels:
+        app: fortio-client
+    spec:
+      containers:
+      - name: fortio-client
+        image: fortio/fortio:latest_release
+        imagePullPolicy: Always

--- a/manifests/samples/fortio/fortio.yaml
+++ b/manifests/samples/fortio/fortio.yaml
@@ -8,7 +8,11 @@ metadata:
 spec:
   ports:
   - port: 8080
-    name: http
+    name: http-8080
+  - port: 8078
+    name: tcp-8078
+  - port: 8079
+    name: grpc-8079
   selector:
     app: fortio
 ---
@@ -33,5 +37,7 @@ spec:
         ports:
         - containerPort: 8080
           name: http
+        - containerPort: 8078
+          name: tcp
         - containerPort: 8079
           name: grpc


### PR DESCRIPTION
Adds the guide and demo for local rate limiting
capability.

Currently, this is limited to L4 connection level
rate limiting, at par with OSM capability.

Adds and updates (uses named ports for protocol selection)
required demo manifests.


Part of openservicemesh/osm#2018