### PR TITLE
docs: add GitHub support files for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,157 @@ The OSM website accepts contributions via GitHub pull requests. This document ou
 
 This is the contribution guide for the [openservicemesh.io](https://openservicemesh.io) website. Go to [openservicemesh/osm](https://github.com/openservicemesh/osm/blob/main/CONTRIBUTING.md) for the core project.
 
-## Sign Your Work
+
+## Pull Request Workflow
+
+The following sections describe how to contribute code by opening a pull request.
+
+### 1. Fork the [Open Service Mesh Docs](https://github.com/openservicemesh/osm-docs) repository
+
+1. Visit `https://github.com/openservicemesh/osm-docs`.
+1. Click the `Fork` button.
+
+### 2. Clone the new fork to your workstation
+
+Set `GITHUB_USERNAME` to match your Github username:
+
+```sh
+export GITHUB_USERNAME=<github username>
+```
+
+Clone and set up your fork:
+
+```sh
+git clone git@github.com:$GITHUB_USERNAME/osm-docs.git
+
+cd osm
+git remote add upstream git@github.com:openservicemesh/osm-docs.git
+
+# Block accidental pushes to upstream's main branch
+git remote set-url --push upstream no_push
+
+# Verify your remote
+git remote -v
+```
+
+### 3. Git branch
+
+Get your local `main` branch up to date with upstream's `main` branch:
+
+```sh
+git fetch upstream
+git checkout main
+git rebase upstream/main
+```
+
+Create a local branch from `main` for your development:
+
+```sh
+# While on the main branch
+git checkout -b <branch name>
+# ex: git checkout -b feature
+```
+
+Keep your branch up to date during development:
+
+```sh
+git fetch upstream
+git rebase upstream/main
+
+# or: git pull --rebase upstream main
+```
+
+### 4. Commit
+
+Make code changes on the `feature` branch and commit them with your signature
+
+```sh
+git commit -s
+```
+
+Follow the [commit style guidelines](#commit-style-guideline).
+
+Make sure to squash your commits before opening a pull request. This is preferred so that your pull request can be merged as is without requesting to be squashed before merge if possible.
+
+### 5. Push
+
+Push your branch to your remote fork:
+
+```sh
+git push -f <remote name> <branch name>
+```
+
+### 6. Open a pull request
+
+1. Visit your fork at `https://github.com/$GITHUB_USERNAME/osm-docs`.
+1. Open a pull request from your `feature` branch using the `Compare & Pull Request` button.
+1. Fill the pull request template and provide enough description so that it can be reviewed.
+
+If your pull request is not ready to be reviewed, open it as a draft.
+
+#### Get code reviewed
+
+Your pull request will be reviewed by the maintainers to ensure correctness. Reviewers might approve the pull request or suggest improvements to make before the changes can be committed.
+
+When addressing review comments, refrain from rewriting the Git history of your branch (e.g. with `git commit --amend` or `git rebase`) where possible to make those changes easy to review. Instead, prefer creating new commits without `--amend` and using `git merge` to resolve conflicts with the upstream branch. The commit style guidelines below will not be enforced for follow-up commits. When the PR is merged, all commits in the PR will automatically be squashed into one commit added to the upstream branch.
+
+### Merging pull requests
+
+Pull requests by default must be merged by a core maintainer.
+Maintainers can add the `automerge` or `autorebase` label to a pull request, additional details [here](docs/automerge.md).
+
+Pull requests will be merged based on the following criteria:
+
+- Has at least two LGTM from a core maintainer.
+- Commits follow the [commit style guidelines](#commit-style-guideline).
+- Does not have the `do-not-merge/hold` label.
+- Does not have the `wip` label.
+- All status checks have succeeded.
+- Commits in the pull request are squashed and have a valid [signature](#sign-your-work). If the commits in the PR are not squashed, maintainers must use the `squash and merge` option to squash the commits before merging. Maintainers may choose to update the commit message to meet the commit message guidelines without altering the signatures of the authors of the pull request. In certain situations, it is okay to have multiple related but independent commits in the same pull request. In such cases, a pull request may be merged as a `merge commit`.
+- If the person who opened the pull request is a core maintainer, then only that person is expected to merge once it has the necessary LGTMs/reviews. Another maintainer can merge the pull request at their discretion if they feel the pull request must be merged urgently.
+
+Maintainers may edit the commit message for `Squash and merge`d PRs to remove messages from follow-up commits.
+
+### Commit Style Guideline
+
+We follow a rough convention for commit messages borrowed from [Deis](https://github.com/deis/deis/blob/master/CONTRIBUTING.md#commit-style-guideline). This is an example of a commit:
+
+```vim
+feat(scripts/test-cluster): add a cluster test command
+
+Adds test experience where there was none before
+and resolves #1213243.
+```
+
+This is a more formal template:
+
+```vim
+{type}({scope}): {subject}
+<BLANK LINE>
+{body}
+```
+
+The `{scope}` can be anything specifying the place of the commit change. Use `*` to denote multiple areas (i.e. `scripts/*: refactored lots of stuff`).
+
+The `{subject}` needs to use imperative, present tense: `change` not `changed` nor `changes`. The first letter should not be capitalized, and there is no dot (`.`) at the end.
+
+Just like the `{subject}`, the message `{body}` needs to be in the present tense and includes the motivation for the change as well as a contrast with the previous behavior. The first letter in the paragraph must be capitalized. If there is an issue number associate with the chunk of work that should be mentioned in this section as well so that it may be closed once the PR with this commit is merged.
+
+Any line of the commit message cannot be longer than 72 characters, with the subject line limited to 50 characters. This allows the message to be easier to read on GitHub as well as in various git tools.
+
+The allowed types for `{type}` are as follows:
+
+```text
+feat -> feature
+fix -> bug fix
+docs -> documentation
+style -> formatting
+ref -> refactoring code
+test -> adding missing tests
+chore -> maintenance
+```
+
+### Sign Your Work
 
 The sign-off is a simple line at the end of the explanation for a commit. All commits needs to be
 signed. Your signature certifies that you wrote the patch or otherwise have the right to contribute
@@ -74,3 +224,19 @@ Date:   Thu Feb 2 11:41:15 2018 -0800
 Notice the `Author` and `Signed-off-by` lines match. If they don't your PR will be rejected by the
 automated DCO check.
 
+
+## Roadmap
+
+We use [GitHub Project Boards](https://github.com/openservicemesh/osm-docs/projects) to help give a high level overview and track what work is going on and what stage it is in.
+
+## Issues
+
+If a bug is found, need clarification, or want to propose a feature, submit an issue using [GitHub issues](https://github.com/openservicemesh/osm-docs/issues).
+
+## Semantic Versioning
+
+OSM and the OSM documentation releases will follow [semantic versioning](https://semver.org/) for labeling releases to maintain backwards compatibility. OSM features and functionality may be added in major (x.0.0) and minor (0.x.0) releases. OSM bug fixes may be added in patch releases (0.0.x). We will follow semantic versioning to guarantee features, flags, functionality, public APIs will be backwards compatible as the versioning scheme suggests. OSM documentation will be released as part of an OSM release.
+
+## Attribution
+
+Please properly attribute any code that is copied or inspired by another project to the author(s) of the work. Read the license of the original project to understand how to properly attribute work from that project and include this in your pull request.

--- a/SUPPORT
+++ b/SUPPORT
@@ -1,0 +1,3 @@
+# Support
+
+[Please search open issues on GitHub](https://github.com/openservicemesh/osm-docs/issues), and if your issue isn't already represented please [open a new one](https://github.com/openservicemesh/osm-docs/issues/new). The OSM project maintainers will respond to the best of their abilities.


### PR DESCRIPTION
Signed-off-by: Zach Rhoads <zachary.rhoads@microsoft.com>

Added GitHub support files, similar to the main repo, to help contributors.