### PR TITLE
docs: remove unsupported versions release list and update banner link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -88,7 +88,10 @@ breadcrumb_disable = false
 sidebar_search_disable = false
 
 [[params.versions]]
-  version = "v1.1 (latest)"
+  version = "v1.2 (latest)"
+  url = "https://release-v1-2.docs.openservicemesh.io/"
+[[params.versions]]
+  version = "v1.1"
   url = "https://release-v1-1.docs.openservicemesh.io/"
 [[params.versions]]
   version = "v1.0"

--- a/config.toml
+++ b/config.toml
@@ -88,21 +88,15 @@ breadcrumb_disable = false
 sidebar_search_disable = false
 
 [[params.versions]]
-  version = "v0.11 (latest)"
-  url = "https://release-v0-11.docs.openservicemesh.io/"
+  version = "v1.1 (latest)"
+  url = "https://release-v1-1.docs.openservicemesh.io/"
 [[params.versions]]
-  version = "v0.10"
-  url = "https://release-v0-10.docs.openservicemesh.io/"
-[[params.versions]]
-  version = "v0.9"
-  url = "https://release-v0-9.docs.openservicemesh.io/"
-[[params.versions]]
-  version = "v0.8"
-  url = "https://release-v0-8.docs.openservicemesh.io/"
+  version = "v1.0"
+  url = "https://release-v1-0.docs.openservicemesh.io/"
 [params.versionbanner]
 	show = true
 	archive = "v0.8"
-	latest = "https://release-v0-11.docs.openservicemesh.io/"
+	latest = "https://docs.openservicemesh.io/"
 
 
 [params.ui.feedback]

--- a/config.toml
+++ b/config.toml
@@ -93,6 +93,9 @@ sidebar_search_disable = false
 [[params.versions]]
   version = "v1.0"
   url = "https://release-v1-0.docs.openservicemesh.io/"
+[[params.versions]]
+  version = "All Releases"
+  url = "https://docs.openservicemesh.io/docs/releases/docs"
 [params.versionbanner]
 	show = true
 	archive = "v0.8"


### PR DESCRIPTION
Signed-off-by: Zach Rhoads <zachary.rhoads@microsoft.com>

Updated release list to supported versions and redirect banner to latest release. This is consistent with https://github.com/openservicemesh/osm/pull/4853