### PR TITLE
docs: remove unsupported versions release list and update banner link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -92,6 +92,9 @@ envoy_version = "v1.19.1"
 [[params.versions]]
   version = "v1.0"
   url = "https://release-v1-0.docs.openservicemesh.io/"
+[[params.versions]]
+  version = "All Releases"
+  url = "https://docs.openservicemesh.io/docs/releases/docs"
 [params.versionbanner]
 	show = true
 	archive = "v1.0"

--- a/config.toml
+++ b/config.toml
@@ -87,20 +87,15 @@ osm_version = "v1.0.0"
 envoy_version = "v1.19.1"
 
 [[params.versions]]
-  version = "v1.0 (latest)"
+  version = "v1.1 (latest)"
+  url = "https://release-v1-1.docs.openservicemesh.io/"
+[[params.versions]]
+  version = "v1.0"
   url = "https://release-v1-0.docs.openservicemesh.io/"
-[[params.versions]]
-  version = "v0.11"
-  url = "https://release-v0-11.docs.openservicemesh.io/"
-[[params.versions]]
-  version = "v0.10"
-  url = "https://release-v0-10.docs.openservicemesh.io/"
-[[params.versions]]
-  version = "v0.9"
-  url = "https://release-v0-9.docs.openservicemesh.io/"
-[[params.versions]]
-  version = "v0.8"
-  url = "https://release-v0-8.docs.openservicemesh.io/"
+[params.versionbanner]
+	show = true
+	archive = "v1.0"
+	latest = "https://docs.openservicemesh.io/"
 
 [params.ui]
 navbar_logo = true

--- a/config.toml
+++ b/config.toml
@@ -87,7 +87,10 @@ osm_version = "v1.0.0"
 envoy_version = "v1.19.1"
 
 [[params.versions]]
-  version = "v1.1 (latest)"
+  version = "v1.2 (latest)"
+  url = "https://release-v1-2.docs.openservicemesh.io/"
+[[params.versions]]
+  version = "v1.1"
   url = "https://release-v1-1.docs.openservicemesh.io/"
 [[params.versions]]
   version = "v1.0"

--- a/themes/dosmy/assets/scss/main.scss
+++ b/themes/dosmy/assets/scss/main.scss
@@ -578,3 +578,42 @@ footer {
     }
   }
 }
+
+
+#banner {
+  background: $blue;
+  color: white;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin: 0;
+  text-align: center;
+  z-index: 1450;
+  display: none;
+
+  p {
+    color: white;
+    padding: 0.333rem 0 0.35rem;
+    margin: 0;
+    font-size: 1rem;
+  }
+
+  a {
+    color: white;
+    @include transition;
+    border-bottom: 2px solid rgba(255,255,255,0.5);
+  }
+}
+
+body.has-banner {
+  padding-top: 1.5rem;
+
+  #banner {
+    display: block;
+  }
+
+  .td-navbar {
+    top: 1.5rem;
+  }
+}

--- a/themes/dosmy/layouts/docs/baseof.html
+++ b/themes/dosmy/layouts/docs/baseof.html
@@ -1,9 +1,10 @@
+{{ $hasbanner := .Site.Params.versionbanner }}
 <!doctype html>
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
   </head>
-  <body class="td-{{ .Kind }}">
+  <body class="td-{{ .Kind }} {{ if $hasbanner.show }} has-banner{{ end }}">
     <header>
       {{ partial "navbar.html" . }}
     </header>

--- a/themes/dosmy/layouts/partials/banner.html
+++ b/themes/dosmy/layouts/partials/banner.html
@@ -1,0 +1,11 @@
+<div id="banner">
+    <!-- viewing helm 3 version of site (desktop) -->
+    <p class="center text-center d-none d-lg-block">
+      You are viewing docs for the {{ .Site.Params.versionbanner.archive }} release. View the docs for the latest release <a href="{{ .Site.Params.versionbanner.latest }}">here</a>
+    </p>
+  
+    <!-- viewing helm 3 version of site (mobile) -->
+    <p class="center text-center d-lg-none">
+      Viewing {{ .Site.Params.versionbanner.archive }} docs. <a href="{{ .Site.Params.versionbanner.latest }}">Latest changes</a>.
+    </p>
+  </div>

--- a/themes/dosmy/layouts/partials/navbar.html
+++ b/themes/dosmy/layouts/partials/navbar.html
@@ -1,4 +1,6 @@
 {{ $cover := .HasShortcode "blocks/cover" }}
+
+{{ partial "banner.html" . }}
 <nav class="js-navbar-scroll navbar navbar-expand {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar">
         <a class="navbar-brand" href="{{ .Site.Params.project_home }}">
 		<span class="navbar-logo">{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}{{ end }}</span><span class="text-uppercase font-weight-bold">{{ .Site.Title }}</span>


### PR DESCRIPTION
Signed-off-by: Zach Rhoads <zachary.rhoads@microsoft.com>

Updated release list to supported versions and redirect banner to latest release. This is consistent with https://github.com/openservicemesh/osm/pull/4853