### PR TITLE
docs: add banner and toggle config for previous versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,12 @@ Proceed with the following steps once the release branch has been created in the
 2. Each previous release-specific site that is still supported needs to be able to access the latest release from the Release drop down. On the previous release branches, update the [config.toml](https://github.com/openservicemesh/osm-docs/blob/main/config.toml) to list the new release version as shown above.
 3. The `latest` tag must be removed from all previous versions. For example, the `latest` tag must be removed from `v0.7 (latest)` on the `release-v0.7` branch.
 4. Add the [banner](https://github.com/openservicemesh/osm-docs/blob/release-v0.9/themes/dosmy/layouts/partials/banner.html) to a previous release specific site if it has not been configured.
-5. Add or update the version banner parameter in `config.toml` to enable the banner at the top of each previous release-specific site that will tell visitors which version they are looking at. For example, the version banner for `release-v0-7` would be configured as follows:
+5. Update the version banner parameter in `config.toml` to enable the banner at the top of each previous release-specific site that will tell visitors which version they are looking at. For example, the version banner for `release-v0-7` would be configured as follows:
 
     ```toml
     [params.versionbanner]
 	    show = true
 	    archive = "v0.7"
-	    latest = "https://release-v0-8.docs.openservicemesh.io/"
     ```
 
 ### Update the release support matrix

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Proceed with the following steps once the release branch has been created in the
 	    show = true
 	    archive = "v0.7"
     ```
+6. Update `content/docs/releases/docs.md` to include the new release and update the inactive releases list.
 
 ### Update the release support matrix
 

--- a/config.toml
+++ b/config.toml
@@ -105,6 +105,10 @@ min_k8s_version = "v1.22.9"
 [[params.versions]]
   version = "v0.8"
   url = "https://release-v0-8.docs.openservicemesh.io/"
+[params.versionbanner]
+	show = false
+	archive = "v1.0"
+	latest = "https://docs.openservicemesh.io/"
 
 [params.ui]
 navbar_logo = true

--- a/config.toml
+++ b/config.toml
@@ -93,10 +93,13 @@ min_k8s_version = "v1.22.9"
 [[params.versions]]
   version = "v1.0"
   url = "https://release-v1-0.docs.openservicemesh.io/"
+[[params.versions]]
+  version = "All Releases"
+  url = "/docs/releases/docs"
 [params.versionbanner]
 	show = false
 	archive = "v1.0"
-	latest = "https://docs.openservicemesh.io/"
+	latest = "https://docs.openservicemesh.io/docs/releases/docs"
 
 [params.ui]
 navbar_logo = true

--- a/config.toml
+++ b/config.toml
@@ -93,18 +93,6 @@ min_k8s_version = "v1.22.9"
 [[params.versions]]
   version = "v1.0"
   url = "https://release-v1-0.docs.openservicemesh.io/"
-[[params.versions]]
-  version = "v0.11"
-  url = "https://release-v0-11.docs.openservicemesh.io/"
-[[params.versions]]
-  version = "v0.10"
-  url = "https://release-v0-10.docs.openservicemesh.io/"
-[[params.versions]]
-  version = "v0.9"
-  url = "https://release-v0-9.docs.openservicemesh.io/"
-[[params.versions]]
-  version = "v0.8"
-  url = "https://release-v0-8.docs.openservicemesh.io/"
 [params.versionbanner]
 	show = false
 	archive = "v1.0"

--- a/content/docs/releases/docs.md
+++ b/content/docs/releases/docs.md
@@ -1,0 +1,20 @@
+---
+title: "All Documentation Releases"
+description: "A complete listing of all OSM documentation releases"
+type: docs
+weight: 2
+---
+
+# All Documentation Releases
+
+## Active Releases
+
+- [v1.1](https://release-v1-1.docs.openservicemesh.io/)
+- [v1.0](https://release-v1-0.docs.openservicemesh.io/)
+
+## Inactive Releases
+
+- [v0.11](https://release-v0-11.docs.openservicemesh.io/)
+- [v0.10](https://release-v0-10.docs.openservicemesh.io/)
+- [v0.9](https://release-v0-9.docs.openservicemesh.io/)
+- [v0.8](https://release-v0-8.docs.openservicemesh.io/)

--- a/themes/dosmy/assets/scss/main.scss
+++ b/themes/dosmy/assets/scss/main.scss
@@ -578,3 +578,41 @@ footer {
     }
   }
 }
+
+#banner {
+  background: $blue;
+  color: white;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin: 0;
+  text-align: center;
+  z-index: 1450;
+  display: none;
+
+  p {
+    color: white;
+    padding: 0.333rem 0 0.35rem;
+    margin: 0;
+    font-size: 1rem;
+  }
+
+  a {
+    color: white;
+    @include transition;
+    border-bottom: 2px solid rgba(255,255,255,0.5);
+  }
+}
+
+body.has-banner {
+  padding-top: 1.5rem;
+
+  #banner {
+    display: block;
+  }
+
+  .td-navbar {
+    top: 1.5rem;
+  }
+}

--- a/themes/dosmy/layouts/docs/baseof.html
+++ b/themes/dosmy/layouts/docs/baseof.html
@@ -1,9 +1,10 @@
+{{ $hasbanner := .Site.Params.versionbanner }}
 <!doctype html>
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
   </head>
-  <body class="td-{{ .Kind }}">
+  <body class="td-{{ .Kind }} {{ if $hasbanner.show }} has-banner{{ end }}">
     <header>
       {{ partial "navbar.html" . }}
     </header>

--- a/themes/dosmy/layouts/partials/banner.html
+++ b/themes/dosmy/layouts/partials/banner.html
@@ -1,0 +1,11 @@
+<div id="banner">
+    <!-- viewing helm 3 version of site (desktop) -->
+    <p class="center text-center d-none d-lg-block">
+      You are viewing docs for the {{ .Site.Params.versionbanner.archive }} release. View the docs for the latest release <a href="{{ .Site.Params.versionbanner.latest }}">here</a>
+    </p>
+  
+    <!-- viewing helm 3 version of site (mobile) -->
+    <p class="center text-center d-lg-none">
+      Viewing {{ .Site.Params.versionbanner.archive }} docs. <a href="{{ .Site.Params.versionbanner.latest }}">Latest changes</a>.
+    </p>
+  </div>

--- a/themes/dosmy/layouts/partials/navbar.html
+++ b/themes/dosmy/layouts/partials/navbar.html
@@ -1,4 +1,6 @@
 {{ $cover := .HasShortcode "blocks/cover" }}
+
+{{ partial "banner.html" . }}
 <nav class="js-navbar-scroll navbar navbar-expand {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar">
         <a class="navbar-brand" href="{{ .Site.Params.project_home }}">
 		<span class="navbar-logo">{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}{{ end }}</span><span class="text-uppercase font-weight-bold">{{ .Site.Title }}</span>


### PR DESCRIPTION
- Updated style and HTML to always have previous versions banner available.
- Added toml config to disable by default. This can be changed to enable when newer release is available.
- Updated readme with correct instructions

Signed-off-by: Zach Rhoads <zachary.rhoads@microsoft.com>