### PR TITLE
docs: update config.toml and netify.toml for 1.2

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -93,8 +93,12 @@ osm_version = "v1.2.0"
 envoy_version = "v1.22.2"
 min_k8s_version = "v1.22.9"
 
+
 [[params.versions]]
-  version = "v1.1 (latest)"
+  version = "v1.2 (latest)"
+  url = "https://release-v1-2.docs.openservicemesh.io/"
+[[params.versions]]
+  version = "v1.1"
   url = "https://release-v1-1.docs.openservicemesh.io/"
 [[params.versions]]
   version = "v1.0"

--- a/content/en/docs/releases/docs.md
+++ b/content/en/docs/releases/docs.md
@@ -9,6 +9,7 @@ weight: 2
 
 ## Active Releases
 
+- [v1.2](https://release-v1-2.docs.openservicemesh.io/)
 - [v1.1](https://release-v1-1.docs.openservicemesh.io/)
 - [v1.0](https://release-v1-0.docs.openservicemesh.io/)
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,5 +10,5 @@
 
 [[redirects]]
   from = "https://docs.openservicemesh.io/*"
-  to = "https://release-v1-1.docs.openservicemesh.io/:splat"
+  to = "https://release-v1-2.docs.openservicemesh.io/:splat"
   force = true


### PR DESCRIPTION
add 1.2 release to dropdown and added redirect from main url to 1.2 docs