### PR TITLE
Lowercase to support files system that aren't case sensitive

### DIFF
--- a/content/en/docs/getting_started/setup_osm.md
+++ b/content/en/docs/getting_started/setup_osm.md
@@ -27,7 +27,7 @@ The binary is available on the [OSM GitHub releases page](https://github.com/ope
 
 Download the 64-bit GNU/Linux or macOS binary of OSM {{< param osm_version >}}:
 ```bash
-system=$(uname -s)
+system=$(uname -s | tr '[:upper:]' '[:lower:]')
 release={{< param osm_version >}}
 curl -L https://github.com/openservicemesh/osm/releases/download/${release}/osm-${release}-${system}-amd64.tar.gz | tar -vxzf -
 ./${system}-amd64/osm version


### PR DESCRIPTION
When following the install instructions at https://release-v1-2.docs.openservicemesh.io/docs/getting_started/setup_osm/#for-gnulinux-and-macos

I got the following on Ubuntu:

```
./${system}-amd64/osm version
-bash: ./Linux-amd64/osm: No such file or directory
```

The folder was `linux-amd64`.  This makes sure that the files are lowercased and should work on Mac's as well