### PR TITLE
demo: update the traffic split docs to meet expectations for root services

### DIFF
--- a/content/en/docs/getting_started/traffic_split.md
+++ b/content/en/docs/getting_started/traffic_split.md
@@ -7,7 +7,7 @@ weight: 4
 
 # Configure Traffic Split between Two Services
 
-We will now demonstrate how to balance traffic between two Kubernetes services, commonly known as a traffic split. We will be splitting the traffic directed to the root `bookstore` service between the backends `bookstore` service and `bookstore-v2` service.
+We will now demonstrate how to balance traffic between two Kubernetes services, commonly known as a traffic split. We will be splitting the traffic directed to the *root* `bookstore` service between the backends `bookstore-v1` service and `bookstore-v2` service.  The `bookstore-v1` and `bookstore-v2` services are also known as leaf services.  Learn more on how to configure services for Traffic Splitting in the [traffic Splitting how-to guide](/docs/guides/traffic_management/traffic_split.md)
 
 ### Deploy bookstore v2 application
 
@@ -33,11 +33,13 @@ EOF
 
 - [http://localhost:8082](http://localhost:8082) - **bookstore-v2**
 
-The counter should _not_ be incrementing because no traffic is flowing yet to the `bookstore-v2` service.
+The `bookstore-v2` counter should be incrementing because traffic to the root `bookstore` service is configured with a label selector which selects endpoints that include both the `bookstore-v1` and `bookstore-v2` backend pods.
 
 ### Create SMI Traffic Split
 
-Deploy the SMI traffic split policy to direct 100 percent of the traffic sent to the root `bookstore` service to the `bookstore` service backend. This is effectively the same as not having a `TrafficSplit` configuration as we are directing 100 percent of traffic from the root service to itself. However, the `TrafficSplit` configuration will be subsequently updated to direct a percentage of traffic to `version v2` of the bookstore service using the `bookstore-v2` leaf service. For this reason, it is important to ensure client applications always communicate with the root service if a traffic split is desired later on, otherwise the client application will need to be updated to communicate with the root service when a traffic split is desired.
+Deploy the SMI traffic split policy to direct 100 percent of the traffic sent to the root `bookstore` service to the `bookstore-v1` service backend. This is necessary to ensure traffic directed to the `bookstore` service is only directed to `version v1` of the bookstore app, which includes the pods backing the `bookstore-v1` service. The `TrafficSplit` configuration will be subsequently updated to direct a percentage of traffic to `version v2` of the bookstore service using the `bookstore-v2` leaf service. 
+
+For this reason, it is important to ensure client applications always communicate with the root service if a traffic split is desired. Otherwise the client application will need to be updated to communicate with the *root* service when a traffic split is desired.
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/split/traffic-split-v1.yaml
@@ -45,7 +47,7 @@ kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< 
 
 _Note: The root service is a Kubernetes service whose selector needs to match the pods backing the leaf services. In this demo, the root service `bookstore` has the selector `app:bookstore`, which matches both the labels `app:bookstore,version:v1` and `app:bookstore,version=v2` on the `bookstore (v1)` and `bookstore-v2` deployments respectively. The root service can be referred to in the SMI Traffic Split resource as the name of the service with or without the `.<namespace>.svc.cluster.local` suffix._
 
-The count for the books sold from the `bookstore-v2` browser window should remain at 0. This is because the current traffic split policy is currently weighted 100 for `bookstore` in addition to the fact that `bookbuyer` is sending traffic to the `bookstore` service and no application is sending requests to the `bookstore-v2` service. You can verify the traffic split policy by running the following and viewing the **Backends** properties:
+The count for the books sold from the `bookstore-v2` browser window should stop incrementing. This is because the current traffic split policy is weighted 100 for `bookstore-v1` which exludes pods backing the `bookstore-v2` service. You can verify the traffic split policy by running the following and viewing the **Backends** properties:
 
 ```bash
 kubectl describe trafficsplit bookstore-split -n bookstore

--- a/manifests/apps/bookstore.yaml
+++ b/manifests/apps/bookstore.yaml
@@ -1,4 +1,7 @@
-# Create bookstore Service
+# Create bookstore root Service.
+# This is the service clients direct traffic to which is also
+# used as the root service in a TrafficSplit configuration when
+# splitting traffic to multiple versions of the backend app.
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,6 +15,25 @@ spec:
     name: bookstore-port
   selector:
     app: bookstore
+
+---
+
+# Create bookstore-v1 service
+apiVersion: v1
+kind: Service
+metadata:
+  name: bookstore-v1
+  namespace: bookstore
+  labels:
+    app: bookstore
+    version: v1
+spec:
+  ports:
+  - port: 14001
+    name: bookstore-port
+  selector:
+    app: bookstore
+    version: v1
 
 ---
 

--- a/manifests/split/traffic-split-50-50.yaml
+++ b/manifests/split/traffic-split-50-50.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   service: bookstore.bookstore # <root-service>.<namespace>
   backends:
-  - service: bookstore
+  - service: bookstore-v1 # matches app:bookstore,version:v1
     weight: 50
-  - service: bookstore-v2
+  - service: bookstore-v2 # matches app:bookstore,version:v2
     weight: 50

--- a/manifests/split/traffic-split-v1.yaml
+++ b/manifests/split/traffic-split-v1.yaml
@@ -13,5 +13,5 @@ spec:
 #   - bookstore.bookstore.svc.cluster.local
   service: bookstore.bookstore # <root-service>.<namespace>
   backends:
-  - service: bookstore
+  - service: bookstore-v1 # matches app:bookstore,version:v1
     weight: 100

--- a/manifests/split/traffic-split-v2.yaml
+++ b/manifests/split/traffic-split-v2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   service: bookstore.bookstore # <root-service>.<namespace>
   backends:
-  - service: bookstore
+  - service: bookstore-v1 # matches app:bookstore,version:v1
     weight: 0
-  - service: bookstore-v2
+  - service: bookstore-v2 # matches app:bookstore,version:v2
     weight: 100


### PR DESCRIPTION
Signed-off-by: James Sturtevant <jstur@microsoft.com>

When running the demo at https://release-v1-2.docs.openservicemesh.io/docs/getting_started/traffic_split/#deploy-bookstore-v2-application even though the docs state: `The counter should not be incrementing because no traffic is flowing yet to the bookstore-v2 service.`

I was seeing traffic flow.  This was because the Kubernetes service was selecting all pods with the label `app: bookstore`  ~where as it should have been selecting just v1.~ as it was the root service.  

This is a follow up to https://github.com/openservicemesh/osm-docs/pull/413 where this change was initially made

