### PR TITLE
docs/rate-limit: add global rate limit demo and docs

### DIFF
--- a/content/en/docs/api_reference/policy/v1alpha1.md
+++ b/content/en/docs/api_reference/policy/v1alpha1.md
@@ -391,6 +391,100 @@ The destination port of the traffic is matched against the list of Ports specifi
 </tr>
 </tbody>
 </table>
+<h3 id="policy.openservicemesh.io/v1alpha1.GenericKeyDescriptorEntry">GenericKeyDescriptorEntry
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.HTTPGlobalRateLimitDescriptorEntry">HTTPGlobalRateLimitDescriptorEntry</a>)
+</p>
+<p>
+<p>GenericKeyDescriptorEntry defines a descriptor entry with a static
+key-value pair.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Value defines the descriptor entry&rsquo;s value.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>key</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Key defines the descriptor entry&rsquo;s key.
+Defaults to &lsquo;generic_key&rsquo;.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.GlobalRateLimitSpec">GlobalRateLimitSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.RateLimitSpec">RateLimitSpec</a>)
+</p>
+<p>
+<p>GlobalRateLimitSpec defines the global rate limiting specification
+for the upstream host.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>tcp</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.TCPGlobalRateLimitSpec">
+TCPGlobalRateLimitSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TCP defines the global rate limiting specification at the network
+level. This has the ultimate effect of rate limiting connections
+per unit of time that arrive at the upstream host.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>http</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.HTTPGlobalRateLimitSpec">
+HTTPGlobalRateLimitSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>HTTP defines the global rate limiting specification for HTTP traffic.
+This has the ultimate effect of rate limiting HTTP requests
+per unit of time that arrive at the upstream host.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="policy.openservicemesh.io/v1alpha1.HTTPConnectionSettings">HTTPConnectionSettings
 </h3>
 <p>
@@ -465,6 +559,376 @@ uint32
 <p>MaxRetries specifies the maximum number of parallel retries
 allowed to the upstream host.
 Defaults to 4294967295 (2^32 - 1) if not specified.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.HTTPGlobalPerRouteRateLimitSpec">HTTPGlobalPerRouteRateLimitSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.HTTPPerRouteRateLimitSpec">HTTPPerRouteRateLimitSpec</a>)
+</p>
+<p>
+<p>HTTPGlobalPerRouteRateLimitSpec defines the global rate limiting specification
+applied per HTTP route.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>descriptors</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.HTTPGlobalRateLimitDescriptor">
+[]HTTPGlobalRateLimitDescriptor
+</a>
+</em>
+</td>
+<td>
+<p>Descriptors defines the list of rate limit descriptors to use
+in the rate limit service request.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.HTTPGlobalRateLimitDescriptor">HTTPGlobalRateLimitDescriptor
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.HTTPGlobalPerRouteRateLimitSpec">HTTPGlobalPerRouteRateLimitSpec</a>, <a href="#policy.openservicemesh.io/v1alpha1.HTTPGlobalRateLimitSpec">HTTPGlobalRateLimitSpec</a>)
+</p>
+<p>
+<p>HTTPGlobalRateLimitDescriptor defines rate limit descriptor to use
+in the rate limit service request for HTTP requests.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>entries</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.HTTPGlobalRateLimitDescriptorEntry">
+[]HTTPGlobalRateLimitDescriptorEntry
+</a>
+</em>
+</td>
+<td>
+<p>Entries defines the list of rate limit descriptor entries.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.HTTPGlobalRateLimitDescriptorEntry">HTTPGlobalRateLimitDescriptorEntry
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.HTTPGlobalRateLimitDescriptor">HTTPGlobalRateLimitDescriptor</a>)
+</p>
+<p>
+<p>HTTPGlobalRateLimitDescriptorEntry defines the rate limit descriptor entry
+to use in the rate limit service request for HTTP requests.
+Only one of GenericKey, RemoteAddress, RequestHeader, HeaderValueMatch may be set.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>genericKey</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.GenericKeyDescriptorEntry">
+GenericKeyDescriptorEntry
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>GenericKey defines a descriptor entry with a static key-value pair.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>remoteAddress</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.RemoteAddressDescriptorEntry">
+RemoteAddressDescriptorEntry
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RemoteAddress defines a descriptor entry with with key &lsquo;remote_address&rsquo;
+and value equal to the client&rsquo;s IP address derived from the x-forwarded-for header.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>requestHeader</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.RequestHeaderDescriptorEntry">
+RequestHeaderDescriptorEntry
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RequestHeader defines a descriptor entry that is generated only when the
+request header matches the given header name. The value of the descriptor
+entry is derived from the value of the header present in the request.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>headerValueMatch</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.HeaderValueMatchDescriptorEntry">
+HeaderValueMatchDescriptorEntry
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>HeaderValueMatch defines a descriptor entry that is generated when the
+request header matches the given HTTP header match criteria.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.HTTPGlobalRateLimitSpec">HTTPGlobalRateLimitSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.GlobalRateLimitSpec">GlobalRateLimitSpec</a>)
+</p>
+<p>
+<p>HTTPGlobalRateLimitSpec defines the global rate limiting specification
+for HTTP requests.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>rateLimitService</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.RateLimitServiceSpec">
+RateLimitServiceSpec
+</a>
+</em>
+</td>
+<td>
+<p>RateLimitService defines the rate limiting service to use
+as a global rate limiter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>domain</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Domain defines a container for a set of rate limits.
+All domains known to the Ratelimit service must be globally unique.
+They serve as a way to have different rate limit configurations that
+don&rsquo;t conflict.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>descriptors</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.HTTPGlobalRateLimitDescriptor">
+[]HTTPGlobalRateLimitDescriptor
+</a>
+</em>
+</td>
+<td>
+<p>Descriptors defines the list of rate limit descriptors to use
+in the rate limit service request.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Timeout defines the timeout interval for calls to the rate limit service.
+Defaults to 20ms.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>failOpen</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FailOpen defines whether to allow traffic in case of
+communication failure between rate limiting service and the proxy.
+Defaults to true.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>enableXRateLimitHeaders</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EnableXRateLimitHeaders defines whether to include the headers
+X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset on
+responses to clients when the rate limit service is consulted for a request.
+Defaults to false.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>responseStatusCode</code><br/>
+<em>
+uint32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResponseStatusCode defines the HTTP status code to use for responses
+to rate limited requests. Code must be in the 400-599 (inclusive)
+error range. If not specified, a default of 429 (Too Many Requests) is used.
+See <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/type/v3/http_status.proto#enum-type-v3-statuscode">https://www.envoyproxy.io/docs/envoy/latest/api-v3/type/v3/http_status.proto#enum-type-v3-statuscode</a>
+for the list of HTTP status codes supported by Envoy.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.HTTPHeaderMatcher">HTTPHeaderMatcher
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.HeaderValueMatchDescriptorEntry">HeaderValueMatchDescriptorEntry</a>)
+</p>
+<p>
+<p>HTTPHeaderMatcher defines the HTTP header match criteria.
+Only one of Exact, Prefix, Suffix, Regex, Contains, Present may be set.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name defines the name of the header to match.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>exact</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Exact defines the exact value to match.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>prefix</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Prefix defines the prefix value to match.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>suffix</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Suffix defines the suffix value to match.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>regex</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Regex defines the regex value to match.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>contains</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Contains defines the substring value to match.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>present</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Present defines whether the request matches the criteria
+when the header is present. If set to false, header match
+will be performed based on whether the header is absent.</p>
 </td>
 </tr>
 </tbody>
@@ -628,6 +1092,20 @@ HTTPLocalRateLimitSpec
 applied per HTTP route.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>global</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.HTTPGlobalPerRouteRateLimitSpec">
+HTTPGlobalPerRouteRateLimitSpec
+</a>
+</em>
+</td>
+<td>
+<p>Global defines the global rate limiting specification
+applied per HTTP route.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="policy.openservicemesh.io/v1alpha1.HTTPRouteSpec">HTTPRouteSpec
@@ -669,6 +1147,78 @@ HTTPPerRouteRateLimitSpec
 <td>
 <p>RateLimit defines the HTTP rate limiting specification for
 the specified HTTP route.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.HeaderValueMatchDescriptorEntry">HeaderValueMatchDescriptorEntry
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.HTTPGlobalRateLimitDescriptorEntry">HTTPGlobalRateLimitDescriptorEntry</a>)
+</p>
+<p>
+<p>HeaderValueMatchDescriptorEntry defines the descriptor entry that is generated
+when the request header matches the given HTTP header match criteria.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Value defines the descriptor entry&rsquo;s value.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>headers</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.HTTPHeaderMatcher">
+[]HTTPHeaderMatcher
+</a>
+</em>
+</td>
+<td>
+<p>Headers defines the list of HTTP header match criteria.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>key</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Key defines the descriptor entry&rsquo;s key.
+Defaults to &lsquo;header_match&rsquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>expectMatch</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExpectMatch defines whether the request must match the given
+match criteria for the descriptor entry to be generated.
+If set to false, a descriptor entry will be generated when the
+request does not match the match criteria.
+Defaults to true.</p>
 </td>
 </tr>
 </tbody>
@@ -1026,6 +1576,46 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="policy.openservicemesh.io/v1alpha1.RateLimitServiceSpec">RateLimitServiceSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.HTTPGlobalRateLimitSpec">HTTPGlobalRateLimitSpec</a>, <a href="#policy.openservicemesh.io/v1alpha1.TCPGlobalRateLimitSpec">TCPGlobalRateLimitSpec</a>)
+</p>
+<p>
+<p>RateLimitServiceSpec defines the Rate Limit Service specification.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>host</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Host defines the hostname of the rate limiting service.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>port</code><br/>
+<em>
+uint16
+</em>
+</td>
+<td>
+<p>Port defines the port number of the rate limiting service</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="policy.openservicemesh.io/v1alpha1.RateLimitSpec">RateLimitSpec
 </h3>
 <p>
@@ -1054,11 +1644,80 @@ LocalRateLimitSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>Local specified the local rate limiting specification
+<p>Local defines the local rate limiting specification
 for the upstream host.
 Local rate limiting is enforced directly by the upstream
 host without any involvement of a global rate limiting service.
 This is applied as a token bucket rate limiter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>global</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.GlobalRateLimitSpec">
+GlobalRateLimitSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Global defines the global rate limiting specification
+for the upstream host.
+Global rate limiting is enforced by an external rate
+limiting service.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.RemoteAddressDescriptorEntry">RemoteAddressDescriptorEntry
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.HTTPGlobalRateLimitDescriptorEntry">HTTPGlobalRateLimitDescriptorEntry</a>)
+</p>
+<p>
+<p>RemoteAddressDescriptorEntry defines a descriptor entry with
+key &lsquo;remote_address&rsquo; and value equal to the client&rsquo;s IP address
+derived from the x-forwarded-for header.</p>
+</p>
+<h3 id="policy.openservicemesh.io/v1alpha1.RequestHeaderDescriptorEntry">RequestHeaderDescriptorEntry
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.HTTPGlobalRateLimitDescriptorEntry">HTTPGlobalRateLimitDescriptorEntry</a>)
+</p>
+<p>
+<p>RequestHeaderDescriptorEntry defines a descriptor entry that is generated only
+when the request header matches the given header name. The value of the descriptor
+entry is derived from the value of the header present in the request.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name defines the name of the header used to look up the descriptor entry&rsquo;s value.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>key</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Key defines the descriptor entry&rsquo;s key.</p>
 </td>
 </tr>
 </tbody>
@@ -1379,6 +2038,96 @@ Defaults to 5s if not specified.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="policy.openservicemesh.io/v1alpha1.TCPGlobalRateLimitSpec">TCPGlobalRateLimitSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.GlobalRateLimitSpec">GlobalRateLimitSpec</a>)
+</p>
+<p>
+<p>TCPGlobalRateLimitSpec defines the global rate limiting specification
+for TCP connections.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>rateLimitService</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.RateLimitServiceSpec">
+RateLimitServiceSpec
+</a>
+</em>
+</td>
+<td>
+<p>RateLimitService defines the rate limiting service to use
+as a global rate limiter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>domain</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Domain defines a container for a set of rate limits.
+All domains known to the Ratelimit service must be globally unique.
+They serve as a way to have different rate limit configurations that
+don&rsquo;t conflict.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>descriptors</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.TCPRateLimitDescriptor">
+[]TCPRateLimitDescriptor
+</a>
+</em>
+</td>
+<td>
+<p>Descriptors defines the list of rate limit descriptors to use
+in the rate limit service request.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Timeout defines the timeout interval for calls to the rate limit service.
+Defaults to 20ms.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>failOpen</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FailOpen defines whether to allow traffic in case of
+communication failure between rate limiting service and the proxy.
+Defaults to true.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="policy.openservicemesh.io/v1alpha1.TCPLocalRateLimitSpec">TCPLocalRateLimitSpec
 </h3>
 <p>
@@ -1432,6 +2181,79 @@ uint32
 <em>(Optional)</em>
 <p>Burst defines the number of connections above the baseline
 rate that are allowed in a short period of time.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.TCPRateLimitDescriptor">TCPRateLimitDescriptor
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.TCPGlobalRateLimitSpec">TCPGlobalRateLimitSpec</a>)
+</p>
+<p>
+<p>TCPRateLimitDescriptor defines the rate limit descriptor to use
+in the rate limit service request for TCP connections.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>entries</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.TCPRateLimitDescriptorEntry">
+[]TCPRateLimitDescriptorEntry
+</a>
+</em>
+</td>
+<td>
+<p>Entries defines the list of rate limit descriptor entries.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.TCPRateLimitDescriptorEntry">TCPRateLimitDescriptorEntry
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.TCPRateLimitDescriptor">TCPRateLimitDescriptor</a>)
+</p>
+<p>
+<p>TCPRateLimitDescriptorEntry defines the rate limit descriptor entry as a
+key-value pair to use in the rate limit service request for TCP connections.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>key</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Key defines the key of the descriptor entry.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Value defines the value of the descriptor entry.</p>
 </td>
 </tr>
 </tbody>
@@ -1733,5 +2555,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>f3966a3c</code>.
+on git commit <code>dddb8fa5</code>.
 </em></p>

--- a/content/en/docs/demos/global_rate_limit_connections.md
+++ b/content/en/docs/demos/global_rate_limit_connections.md
@@ -18,7 +18,7 @@ This guide demonstrates how to configure global rate limiting for L4 TCP connect
 
 ## Demo
 
-The following demo shows a client [fortio-client](https://github.com/fortio/fortio) sending TCP traffic to the `fortio` `TCP echo` service. The `fortio` service echoes TCP messages back to the client. We will see the impact of applying global TCP rate limiting policies targeting the `fortio` service to control the throughput of traffic destined to the service backend using an external Rate Limit Service (RLS).
+The following demo shows a client [fortio-client](https://github.com/fortio/fortio) sending TCP traffic to the `fortio` TCP echo service. The `fortio` service echoes TCP messages back to the client. We will see the impact of applying global TCP rate limiting policies targeting the `fortio` service to control the throughput of traffic destined to the service backend using an external Rate Limit Service (RLS).
 
 1. For simplicity, enable [permissive traffic policy mode](/docs/guides/traffic_management/permissive_mode) so that explicit SMI traffic access policies are not required for application connectivity within the mesh.
     ```bash
@@ -26,7 +26,7 @@ The following demo shows a client [fortio-client](https://github.com/fortio/fort
     kubectl patch meshconfig osm-mesh-config -n "$osm_namespace" -p '{"spec":{"traffic":{"enablePermissiveTrafficPolicyMode":true}}}'  --type=merge
     ```
 
-1. Deploy the `fortio` `TCP echo` service in the `demo` namespace after enrolling its namespace to the mesh. The `fortio` `TCP echo` service runs on port `8078`.
+1. Deploy the `fortio` TCP echo service in the `demo` namespace after enrolling its namespace to the mesh. The `fortio` TCP echo service runs on port `8078`.
     ```bash
     # Create the demo namespace
     kubectl create namespace demo
@@ -183,7 +183,7 @@ The following demo shows a client [fortio-client](https://github.com/fortio/fort
     ratelimiter-bb7665d55-6qtvv   2/2     Running   0          15s
     ```
 
-1. Confirm the `fortio-client` app is able to successfully make TCP connections and send data to the `fortio` `TCP echo` service on port `8078`. We call the `fortio` service with `3` concurrent connections (`-c 3`) and send `10` calls (`-n 10`).
+1. Confirm the `fortio-client` app is able to successfully make TCP connections and send data to the `fortio` TCP echo service on port `8078`. We call the `fortio` service with `3` concurrent connections (`-c 3`) and send `10` calls (`-n 10`).
     ```console
     $ fortio_client="$(kubectl get pod -n demo -l app=fortio-client -o jsonpath='{.items[0].metadata.name}')"
 

--- a/content/en/docs/demos/global_rate_limit_http.md
+++ b/content/en/docs/demos/global_rate_limit_http.md
@@ -1,0 +1,848 @@
+---
+title: "Global rate limiting of HTTP requests"
+description: "Configuring global rate limiting for HTTP requests"
+type: docs
+weight: 23
+---
+
+This guide demonstrates how to configure global rate limiting for HTTP requests destined to a target host that is a part of an OSM managed service mesh.
+
+## Prerequisites
+
+- Kubernetes cluster running Kubernetes {{< param min_k8s_version >}} or greater.
+- Have OSM installed.
+- Have `kubectl` available to interact with the API server.
+- Have `osm` CLI available for managing the service mesh.
+- OSM version >= v1.3.0.
+
+
+## Demo
+
+The following demo shows a client [fortio-client](https://github.com/fortio/fortio) sending HTTP requests to the `fortio` HTTP service. We will see the impact of applying global HTTP rate limiting policies targeting the `fortio` service to control the throughput of traffic destined to the service backend using an external Rate Limit Service (RLS).
+
+1. For simplicity, enable [permissive traffic policy mode](/docs/guides/traffic_management/permissive_mode) so that explicit SMI traffic access policies are not required for application connectivity within the mesh.
+    ```bash
+    export osm_namespace=osm-system # Replace osm-system with the namespace where OSM is installed
+    kubectl patch meshconfig osm-mesh-config -n "$osm_namespace" -p '{"spec":{"traffic":{"enablePermissiveTrafficPolicyMode":true}}}'  --type=merge
+    ```
+
+1. Deploy the `fortio` HTTP service in the `demo` namespace after enrolling its namespace to the mesh. The `fortio` HTTP service runs on port `8080`.
+    ```bash
+    # Create the demo namespace
+    kubectl create namespace demo
+
+    # Add the namespace to the mesh
+    osm namespace add demo
+
+    # Deploy fortio HTTP in the demo namespace
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/fortio/fortio.yaml -n demo
+    ```
+
+    Confirm the `fortio` service pod is up and running.
+
+    ```console
+    $ kubectl get pods -n demo
+    NAME                            READY   STATUS    RESTARTS   AGE
+    fortio-c4bd7857f-7mm6w          2/2     Running   0          22m
+    ```
+
+1. Deploy the `fortio-client` app in the `demo` namespace. We will use this client to send TCP traffic to the `fortio HTTP` service deployed previously.
+    ```bash
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/{{< param osm_branch >}}/manifests/samples/fortio/fortio-client.yaml -n demo
+    ```
+
+    Confirm the `fortio-client` pod is up and running.
+
+    ```console
+    NAME                            READY   STATUS    RESTARTS   AGE
+    fortio-client-b9b7bbfb8-prq7r   2/2     Running   0          7s
+    ```
+
+1. Deploy the external RLS. Any RLS that implement's [Envoy's Rate Limit Service proto](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ratelimit/v3/rls.proto) can be used as a global rate limiter with Envoy. For this demo, we use the [Envoy Rate Limit Service](https://github.com/envoyproxy/ratelimit) as our RLS. Per the [Envoy RLS overview](https://github.com/envoyproxy/ratelimit#overview):
+    > The rate limit service is a Go/gRPC service designed to enable generic rate limit scenarios from different types of applications. Applications request a rate limit decision based on a domain and a set of descriptors. The service reads the configuration from disk via runtime, composes a cache key, and talks to the Redis cache. A decision is then returned to the caller.
+
+    Create a namespace to deploy the RLS into.
+    ```bash
+    kubectl create namespace rls
+    ```
+
+    Create a ConfigMap that contains the [rate limit configuration](https://github.com/envoyproxy/ratelimit#configuration). In this demo, we will start by rate limit HTTP traffic that generates the descriptor key-value pair `generic_key: my_value` to 1 request per minute.
+    ```bash
+    kubectl apply -f - <<EOF
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ratelimit-config
+      namespace: rls
+    data:
+      ratelimit-config.yaml: |
+        domain: test
+        descriptors:
+          # requests with a descriptor ["generic_key": "my_value"]
+          # are limited to one per minute.
+          - key: generic_key
+            value: my_value
+            rate_limit:
+              unit: minute
+              requests_per_unit: 1
+    EOF
+    ```
+    > Note: it can take a few seconds for the RLS to load the configuration.
+
+    Deploy the global RLS Service and Deployment in the `rls` namespace. The `ratelimiter` Deployment mounts the `ratelimit-config` ConfigMap as a volume, which allows the RLS service to load the rate limit configuration specified in the ConfigMap. We will later reference the `ratelimiter` service to configure global rate limiting within the mesh.
+    ```bash
+    kubectl apply -f - <<EOF
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app: ratelimiter
+      name: ratelimiter
+      namespace: rls
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: ratelimiter
+      template:
+        metadata:
+          labels:
+            app: ratelimiter
+        spec:
+          containers:
+            - name: redis
+              image: redis:alpine
+              env:
+                - name: REDIS_SOCKET_TYPE
+                  value: tcp
+                - name: REDIS_URL
+                  value: redis:6379
+            - name: ratelimiter
+              image: docker.io/envoyproxy/ratelimit:1f4ea68e
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+                - containerPort: 8081
+                  name: grpc
+                  protocol: TCP
+              volumeMounts:
+                - name: ratelimit-config
+                  mountPath: /data/ratelimit/config
+                  readOnly: true
+              env:
+                - name: USE_STATSD
+                  value: "false"
+                - name: LOG_LEVEL
+                  value: debug
+                - name: REDIS_SOCKET_TYPE
+                  value: tcp
+                - name: REDIS_URL
+                  value: localhost:6379
+                - name: RUNTIME_ROOT
+                  value: /data
+                - name: RUNTIME_SUBDIRECTORY
+                  value: ratelimit
+                - name: RUNTIME_WATCH_ROOT
+                  value: "false"
+                # need to set RUNTIME_IGNOREDOTFILES to true to avoid issues with
+                # how Kubernetes mounts configmaps into pods.
+                - name: RUNTIME_IGNOREDOTFILES
+                  value: "true"
+              command: ["/bin/ratelimit"]
+              livenessProbe:
+                httpGet:
+                  path: /healthcheck
+                  port: 8080
+                initialDelaySeconds: 5
+                periodSeconds: 5
+          volumes:
+            - name: ratelimit-config
+              configMap:
+                name: ratelimit-config
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: ratelimiter
+      namespace: rls
+    spec:
+      ports:
+      - port: 8081
+        name: grpc
+        protocol: TCP
+      selector:
+        app: ratelimiter
+      type: ClusterIP
+    EOF
+    ```
+
+    Confirm the RLS pod is up and running.
+    ```console
+    $ kubectl get pods -n rls
+    NAME                          READY   STATUS    RESTARTS   AGE
+    ratelimiter-bb7665d55-6qtvv   2/2     Running   0          15s
+    ```
+
+1. Confirm the `fortio-client` app is able to successfully make HTTP requests to the `fortio` HTTP service on port `8080`. We call the `fortio` service with `3` concurrent connections (`-c 3`) and send `10` requests (`-n 10`).
+    First, save the name of the fortio client and server pods:
+    ```bash
+    fortio_client="$(kubectl get pod -n demo -l app=fortio-client -o jsonpath='{.items[0].metadata.name}')"
+    fortio_server="$(kubectl get pod -n demo -l app=fortio -o jsonpath='{.items[0].metadata.name}')"
+    ```
+
+    ```console
+    $ kubectl exec "$fortio_client" -n demo -c fortio-client -- fortio load -c 3 -n 10 http://fortio.demo.svc.cluster.local:8080
+    Fortio 1.34.1 running at 8 queries per second, 8->8 procs, for 10 calls: http://fortio.demo.svc.cluster.local:8080
+    19:19:26 I httprunner.go:98> Starting http test for http://fortio.demo.svc.cluster.local:8080 with 3 threads at 8.0 qps and parallel warmup
+    Starting at 8 qps with 3 thread(s) [gomax 8] : exactly 10, 3 calls each (total 9 + 1)
+    19:19:27 I periodic.go:721> T001 ended after 1.1276393s : 3 calls. qps=2.6604251909276306
+    19:19:27 I periodic.go:721> T002 ended after 1.1276668s : 3 calls. qps=2.6603603121063775
+    19:19:27 I periodic.go:721> T000 ended after 1.502888s : 4 calls. qps=2.6615423105381106
+    Ended after 1.5030055s : 10 calls. qps=6.6533
+    Sleep times : count 7 avg 0.53181499 +/- 0.03017 min 0.4955405 max 0.5605537 sum 3.7227049
+    Aggregated Function Time : count 10 avg 0.00328438 +/- 0.002132 min 0.0012625 max 0.0075019 sum 0.0328438
+    # range, mid point, percentile, count
+    >= 0.0012625 <= 0.002 , 0.00163125 , 30.00, 3
+    > 0.002 <= 0.003 , 0.0025 , 70.00, 4
+    > 0.004 <= 0.005 , 0.0045 , 80.00, 1
+    > 0.006 <= 0.007 , 0.0065 , 90.00, 1
+    > 0.007 <= 0.0075019 , 0.00725095 , 100.00, 1
+    # target 50% 0.0025
+    # target 75% 0.0045
+    # target 90% 0.007
+    # target 99% 0.00745171
+    # target 99.9% 0.00749688
+    Error cases : no data
+    19:19:27 I httprunner.go:197> [0]   1 socket used, resolved to 10.96.151.249:8080
+    19:19:27 I httprunner.go:197> [1]   1 socket used, resolved to 10.96.151.249:8080
+    19:19:27 I httprunner.go:197> [2]   1 socket used, resolved to 10.96.151.249:8080
+    Sockets used: 3 (for perfect keepalive, would be 3)
+    Uniform: false, Jitter: false
+    IP addresses distribution:
+    10.96.151.249:8080: 3
+    Code 200 : 10 (100.0 %)
+    Response Header Sizes : count 10 avg 124 +/- 0 min 124 max 124 sum 1240
+    Response Body/Total Sizes : count 10 avg 124 +/- 0 min 124 max 124 sum 1240
+    All done 10 calls (plus 0 warmup) 3.284 ms avg, 6.7 qps
+    ```
+
+    As seen above, all the HTTP requests from the `fortio-client` pod succeeded.
+    ```
+    Code 200 : 10 (100.0 %)
+    ```
+
+### Configuring global rate limit policies
+
+Global rate limit policies can be applied to target upstream services in the cluster. The policy can be applied at both the virtual host and route level. The policy defines a set of request descriptors that will be generated and sent to the external RLS to make a rate limiting decision on each request.
+
+Refer to the the [HTTP global rate limiting guide](/docs/guides/traffic_management/rate_limiting/#global-rate-limiting-of-http-requests) to learn more about the configuration attributes.
+
+
+In this demo, we will see the impact of generating different descriptor entries on rate limiting.
+
+#### genericKey descriptor
+
+Recollect that we defined a rate limiting policy in the `ratelimit-config` ConfigMap to rate limit requests that generate the descriptor `generic_key: my_value` to 1 per minute:
+```
+descriptors:
+  # requests with a descriptor ["generic_key": "my_value"]
+  # are limited to 1 per minute.
+  - key: generic_key
+    value: my_value
+    rate_limit:
+      unit: minute
+      requests_per_unit: 1
+```
+
+The `genericKey` descriptor entry defines a static key-value pair. By default, the `genericKey` descriptor entry uses `generic_key` as it's descriptor key if unspecified.
+
+Let's apply a global rate limit policy targeting the `fortio` service to generate the descriptor entry `generic_key: my_value`.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: policy.openservicemesh.io/v1alpha1
+kind: UpstreamTrafficSetting
+metadata:
+  name: fortio-tcp
+  namespace: demo
+spec:
+  host: fortio.demo.svc.cluster.local
+  rateLimit:
+    global:
+      http:
+        rateLimitService:
+          host: ratelimiter.rls.svc.cluster.local
+          port: 8081
+        domain: test
+        failOpen: false
+        timeout: 10s
+        descriptors:
+          - entries:
+            - genericKey:
+                # key: generic_key # default
+                value: my_value
+EOF
+```
+
+Confirm the HTTP requests from the `fortio-client` to the `fortio` service are rate limited.
+
+Reset the stat counters on the `fortio` server pod's Envoy sidecar to see the impact of rate limiting.
+```bash
+osm proxy set reset_counters "$fortio_server" -n demo
+```
+
+```console
+$ kubectl exec "$fortio_client" -n demo -c fortio-client -- fortio load -c 3 -n 10 http://fortio.demo.svc.cluster.local:8080
+Fortio 1.34.1 running at 8 queries per second, 8->8 procs, for 10 calls: http://fortio.demo.svc.cluster.local:8080
+20:41:02 I httprunner.go:98> Starting http test for http://fortio.demo.svc.cluster.local:8080 with 3 threads at 8.0 qps and parallel warmup
+Starting at 8 qps with 3 thread(s) [gomax 8] : exactly 10, 3 calls each (total 9 + 1)
+20:41:02 W http_client.go:889> [1] Non ok http code 429 (HTTP/1.1 429)
+20:41:02 W http_client.go:889> [0] Non ok http code 429 (HTTP/1.1 429)
+20:41:03 W http_client.go:889> [0] Non ok http code 429 (HTTP/1.1 429)
+20:41:03 W http_client.go:889> [1] Non ok http code 429 (HTTP/1.1 429)
+20:41:03 W http_client.go:889> [2] Non ok http code 429 (HTTP/1.1 429)
+20:41:03 W http_client.go:889> [0] Non ok http code 429 (HTTP/1.1 429)
+20:41:03 W http_client.go:889> [1] Non ok http code 429 (HTTP/1.1 429)
+20:41:03 I periodic.go:721> T001 ended after 1.1319728s : 3 calls. qps=2.650240359132304
+20:41:03 W http_client.go:889> [2] Non ok http code 429 (HTTP/1.1 429)
+20:41:03 I periodic.go:721> T002 ended after 1.1405133s : 3 calls. qps=2.630394577599402
+20:41:04 W http_client.go:889> [0] Non ok http code 429 (HTTP/1.1 429)
+20:41:04 I periodic.go:721> T000 ended after 1.5124383s : 4 calls. qps=2.644735986915962
+Ended after 1.5125624s : 10 calls. qps=6.6113
+Sleep times : count 7 avg 0.50386114 +/- 0.03724 min 0.4420604 max 0.5548546 sum 3.527028
+Aggregated Function Time : count 10 avg 0.02527542 +/- 0.02166 min 0.0063666 max 0.0589057 sum 0.2527542
+# range, mid point, percentile, count
+>= 0.0063666 <= 0.007 , 0.0066833 , 20.00, 2
+> 0.007 <= 0.008 , 0.0075 , 30.00, 1
+> 0.012 <= 0.014 , 0.013 , 50.00, 2
+> 0.014 <= 0.016 , 0.015 , 60.00, 1
+> 0.016 <= 0.018 , 0.017 , 70.00, 1
+> 0.05 <= 0.0589057 , 0.0544528 , 100.00, 3
+# target 50% 0.014
+# target 75% 0.0514843
+# target 90% 0.0559371
+# target 99% 0.0586088
+# target 99.9% 0.058876
+Error cases : count 9 avg 0.021538722 +/- 0.01954 min 0.0063666 max 0.0575147 sum 0.1938485
+# range, mid point, percentile, count
+>= 0.0063666 <= 0.007 , 0.0066833 , 22.22, 2
+> 0.007 <= 0.008 , 0.0075 , 33.33, 1
+> 0.012 <= 0.014 , 0.013 , 55.56, 2
+> 0.014 <= 0.016 , 0.015 , 66.67, 1
+> 0.016 <= 0.018 , 0.017 , 77.78, 1
+> 0.05 <= 0.0575147 , 0.0537574 , 100.00, 2
+# target 50% 0.0135
+# target 75% 0.0175
+# target 90% 0.0541331
+# target 99% 0.0571765
+# target 99.9% 0.0574809
+20:41:04 I httprunner.go:197> [0]   4 socket used, resolved to 10.96.151.249:8080
+20:41:04 I httprunner.go:197> [1]   3 socket used, resolved to 10.96.151.249:8080
+20:41:04 I httprunner.go:197> [2]   2 socket used, resolved to 10.96.151.249:8080
+Sockets used: 9 (for perfect keepalive, would be 3)
+Uniform: false, Jitter: false
+IP addresses distribution:
+10.96.151.249:8080: 3
+Code 200 : 1 (10.0 %)
+Code 429 : 9 (90.0 %)
+Response Header Sizes : count 10 avg 12.5 +/- 37.5 min 0 max 125 sum 125
+Response Body/Total Sizes : count 10 avg 162.2 +/- 12.41 min 125 max 167 sum 1622
+All done 10 calls (plus 0 warmup) 25.275 ms avg, 6.6 qps
+```
+
+As seen above, only `1` out of `10` HTTP requests succeeded, while the remaining `9` requests were rate limited with a `429 (Too Many Requests)` response as per the rate limiting policy.
+```
+Code 200 : 1 (10.0 %)
+Code 429 : 9 (90.0 %)
+```
+
+Examine the stats to further confirm this.
+
+```console
+$ osm proxy get stats "$fortio_server" -n demo | grep 'over_limit'
+cluster.demo/fortio|8080|local.ratelimit.over_limit: 9
+```
+
+#### remoteAddress descriptor
+
+A `remoteAddress` descriptor entry has a key of `remote_address` and a value of the client IP address that is populated using the trusted address from the `x-forwarded-for` HTTP header.
+
+Let's update the `ratelimit-config` ConfigMap to rate limit requests from each unique client to 3 per minute.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ratelimit-config
+  namespace: rls
+data:
+  ratelimit-config.yaml: |
+    domain: test
+    descriptors:
+      # each unique remote (client) address is limited to 3 per minute
+      - key: remote_address
+        rate_limit:
+          unit: minute
+          requests_per_unit: 3
+EOF
+```
+> Note: it can take a few seconds for the RLS to load the configuration.
+
+Update global rate limit policy targeting the `fortio` service to generate the `remote_address` descriptor entry.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: policy.openservicemesh.io/v1alpha1
+kind: UpstreamTrafficSetting
+metadata:
+  name: fortio-tcp
+  namespace: demo
+spec:
+  host: fortio.demo.svc.cluster.local
+  rateLimit:
+    global:
+      http:
+        rateLimitService:
+          host: ratelimiter.rls.svc.cluster.local
+          port: 8081
+        domain: test
+        failOpen: false
+        timeout: 10s
+        descriptors:
+          - entries:
+            - remoteAddress: {}
+EOF
+```
+
+Confirm the HTTP requests from the `fortio-client` to the `fortio` service are rate limited.
+
+Reset the stat counters on the `fortio` server pod's Envoy sidecar to see the impact of rate limiting.
+```bash
+osm proxy set reset_counters "$fortio_server" -n demo
+```
+
+```console
+$ kubectl exec "$fortio_client" -n demo -c fortio-client -- fortio load -c 3 -n 10 http://fortio.demo.svc.cluster.local:8080
+Fortio 1.34.1 running at 8 queries per second, 8->8 procs, for 10 calls: http://fortio.demo.svc.cluster.local:8080
+21:12:53 I httprunner.go:98> Starting http test for http://fortio.demo.svc.cluster.local:8080 with 3 threads at 8.0 qps and parallel warmup
+Starting at 8 qps with 3 thread(s) [gomax 8] : exactly 10, 3 calls each (total 9 + 1)
+21:12:54 W http_client.go:889> [0] Non ok http code 429 (HTTP/1.1 429)
+21:12:54 W http_client.go:889> [1] Non ok http code 429 (HTTP/1.1 429)
+21:12:54 W http_client.go:889> [2] Non ok http code 429 (HTTP/1.1 429)
+21:12:54 W http_client.go:889> [0] Non ok http code 429 (HTTP/1.1 429)
+21:12:54 W http_client.go:889> [1] Non ok http code 429 (HTTP/1.1 429)
+21:12:54 I periodic.go:721> T001 ended after 1.1319011s : 3 calls. qps=2.6504082379635467
+21:12:54 W http_client.go:889> [2] Non ok http code 429 (HTTP/1.1 429)
+21:12:54 I periodic.go:721> T002 ended after 1.1328863s : 3 calls. qps=2.648103344528043
+21:12:55 W http_client.go:889> [0] Non ok http code 429 (HTTP/1.1 429)
+21:12:55 I periodic.go:721> T000 ended after 1.5092389s : 4 calls. qps=2.6503425004484047
+Ended after 1.5100615s : 10 calls. qps=6.6222
+Sleep times : count 7 avg 0.52272264 +/- 0.03009 min 0.4810746 max 0.5568693 sum 3.6590585
+Aggregated Function Time : count 10 avg 0.01113793 +/- 0.007175 min 0.0051703 max 0.0265551 sum 0.1113793
+# range, mid point, percentile, count
+>= 0.0051703 <= 0.006 , 0.00558515 , 30.00, 3
+> 0.006 <= 0.007 , 0.0065 , 40.00, 1
+> 0.007 <= 0.008 , 0.0075 , 60.00, 2
+> 0.008 <= 0.009 , 0.0085 , 70.00, 1
+> 0.018 <= 0.02 , 0.019 , 90.00, 2
+> 0.025 <= 0.0265551 , 0.0257776 , 100.00, 1
+# target 50% 0.0075
+# target 75% 0.0185
+# target 90% 0.02
+# target 99% 0.0263996
+# target 99.9% 0.0265395
+Error cases : count 7 avg 0.0066644 +/- 0.001223 min 0.0051703 max 0.0087338 sum 0.0466508
+# range, mid point, percentile, count
+>= 0.0051703 <= 0.006 , 0.00558515 , 42.86, 3
+> 0.006 <= 0.007 , 0.0065 , 57.14, 1
+> 0.007 <= 0.008 , 0.0075 , 85.71, 2
+> 0.008 <= 0.0087338 , 0.0083669 , 100.00, 1
+# target 50% 0.0065
+# target 75% 0.007625
+# target 90% 0.00822014
+# target 99% 0.00868243
+# target 99.9% 0.00872866
+21:12:55 I httprunner.go:197> [0]   3 socket used, resolved to 10.96.151.249:8080
+21:12:55 I httprunner.go:197> [1]   2 socket used, resolved to 10.96.151.249:8080
+21:12:55 I httprunner.go:197> [2]   2 socket used, resolved to 10.96.151.249:8080
+Sockets used: 7 (for perfect keepalive, would be 3)
+Uniform: false, Jitter: false
+IP addresses distribution:
+10.96.151.249:8080: 3
+Code 200 : 3 (30.0 %)
+Code 429 : 7 (70.0 %)
+Response Header Sizes : count 10 avg 37.5 +/- 57.28 min 0 max 125 sum 375
+Response Body/Total Sizes : count 10 avg 153.7 +/- 18.79 min 125 max 166 sum 1537
+All done 10 calls (plus 0 warmup) 11.138 ms avg, 6.6 qps
+```
+
+As seen above, only `3` out of `10` HTTP requests succeeded, while the remaining `7` requests were rate limited with a `429 (Too Many Requests)` response as per the rate limiting policy.
+```
+Code 200 : 3 (30.0 %)
+Code 429 : 7 (70.0 %)
+```
+
+Examine the stats to further confirm this.
+
+```console
+$ osm proxy get stats "$fortio_server" -n demo | grep 'over_limit'
+cluster.demo/fortio|8080|local.ratelimit.over_limit: 7
+```
+
+#### requestHeader descriptor
+
+A `requestHeader` descriptor entry defines a static key-value pair for the descriptor entry that is generated only when the request header matches the given header name. The value of the descriptor entry is derived from the value of the header present in the request.
+
+Let's update the `ratelimit-config` ConfigMap to rate limit requests with the header `my-header: foo` and descriptor key `my_header` to 5 per minute.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ratelimit-config
+  namespace: rls
+data:
+  ratelimit-config.yaml: |
+    domain: test
+    descriptors:
+      # requests with the header 'my-header: foo' are rate limited
+      # to 5 per minute
+      - key: my_header
+        value: foo
+        rate_limit:
+          unit: minute
+          requests_per_unit: 5
+EOF
+```
+> Note: it can take a few seconds for the RLS to load the configuration.
+
+Update global rate limit policy targeting the `fortio` service to generate the `remote_address` descriptor entry.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: policy.openservicemesh.io/v1alpha1
+kind: UpstreamTrafficSetting
+metadata:
+  name: fortio-tcp
+  namespace: demo
+spec:
+  host: fortio.demo.svc.cluster.local
+  rateLimit:
+    global:
+      http:
+        rateLimitService:
+          host: ratelimiter.rls.svc.cluster.local
+          port: 8081
+        domain: test
+        failOpen: false
+        timeout: 10s
+        descriptors:
+          - entries:
+            - requestHeader:
+                name: my-header
+                key: my_header
+EOF
+```
+
+Confirm the HTTP requests with the header `my-header: foo` from the `fortio-client` to the `fortio` service are rate limited.
+
+Reset the stat counters on the `fortio` server pod's Envoy sidecar to see the impact of rate limiting.
+```bash
+osm proxy set reset_counters "$fortio_server" -n demo
+```
+
+```console
+$ kubectl exec "$fortio_client" -n demo -c fortio-client -- fortio load -c 3 -n 10 -H "my-header: foo" http://fortio.demo.svc.cluster.local:8080
+Fortio 1.34.1 running at 8 queries per second, 8->8 procs, for 10 calls: http://fortio.demo.svc.cluster.local:8080
+22:52:57 I httprunner.go:98> Starting http test for http://fortio.demo.svc.cluster.local:8080 with 3 threads at 8.0 qps and parallel warmup
+Starting at 8 qps with 3 thread(s) [gomax 8] : exactly 10, 3 calls each (total 9 + 1)
+22:52:58 W http_client.go:889> [1] Non ok http code 429 (HTTP/1.1 429)
+22:52:58 W http_client.go:889> [0] Non ok http code 429 (HTTP/1.1 429)
+22:52:58 W http_client.go:889> [2] Non ok http code 429 (HTTP/1.1 429)
+22:52:58 I periodic.go:721> T002 ended after 1.129234s : 3 calls. qps=2.656668148497123
+22:52:58 W http_client.go:889> [1] Non ok http code 429 (HTTP/1.1 429)
+22:52:58 I periodic.go:721> T001 ended after 1.1527555s : 3 calls. qps=2.6024599318762736
+22:52:58 W http_client.go:889> [0] Non ok http code 429 (HTTP/1.1 429)
+22:52:58 I periodic.go:721> T000 ended after 1.5212944s : 4 calls. qps=2.629339856900808
+Ended after 1.5213586s : 10 calls. qps=6.5731
+Sleep times : count 7 avg 0.46446531 +/- 0.07222 min 0.3480318 max 0.5554373 sum 3.2512572
+Aggregated Function Time : count 10 avg 0.05466351 +/- 0.06385 min 0.0036194 max 0.1516558 sum 0.5466351
+# range, mid point, percentile, count
+>= 0.0036194 <= 0.004 , 0.0038097 , 10.00, 1
+> 0.006 <= 0.007 , 0.0065 , 20.00, 1
+> 0.007 <= 0.008 , 0.0075 , 30.00, 1
+> 0.008 <= 0.009 , 0.0085 , 40.00, 1
+> 0.016 <= 0.018 , 0.017 , 50.00, 1
+> 0.02 <= 0.025 , 0.0225 , 60.00, 1
+> 0.025 <= 0.03 , 0.0275 , 70.00, 1
+> 0.14 <= 0.151656 , 0.145828 , 100.00, 3
+# target 50% 0.018
+# target 75% 0.141943
+# target 90% 0.147771
+# target 99% 0.151267
+# target 99.9% 0.151617
+Error cases : count 5 avg 0.01562006 +/- 0.008393 min 0.0036194 max 0.0270713 sum 0.0781003
+# range, mid point, percentile, count
+>= 0.0036194 <= 0.004 , 0.0038097 , 20.00, 1
+> 0.008 <= 0.009 , 0.0085 , 40.00, 1
+> 0.016 <= 0.018 , 0.017 , 60.00, 1
+> 0.02 <= 0.025 , 0.0225 , 80.00, 1
+> 0.025 <= 0.0270713 , 0.0260357 , 100.00, 1
+# target 50% 0.017
+# target 75% 0.02375
+# target 90% 0.0260357
+# target 99% 0.0269677
+# target 99.9% 0.0270609
+22:52:58 I httprunner.go:197> [0]   2 socket used, resolved to 10.96.151.249:8080
+22:52:58 I httprunner.go:197> [1]   2 socket used, resolved to 10.96.151.249:8080
+22:52:58 I httprunner.go:197> [2]   1 socket used, resolved to 10.96.151.249:8080
+Sockets used: 5 (for perfect keepalive, would be 3)
+Uniform: false, Jitter: false
+IP addresses distribution:
+10.96.151.249:8080: 3
+Code 200 : 5 (50.0 %)
+Code 429 : 5 (50.0 %)
+Response Header Sizes : count 10 avg 62.6 +/- 62.6 min 0 max 126 sum 626
+Response Body/Total Sizes : count 10 avg 145.9 +/- 20.71 min 124 max 167 sum 1459
+All done 10 calls (plus 0 warmup) 54.664 ms avg, 6.6 qps
+```
+
+As seen above, only `5` out of `10` HTTP requests succeeded, while the remaining `5` requests were rate limited with a `429 (Too Many Requests)` response as per the rate limiting policy.
+```
+Code 200 : 5 (50.0 %)
+Code 429 : 5 (50.0 %)
+```
+
+Examine the stats to further confirm this.
+
+```console
+$ osm proxy get stats "$fortio_server" -n demo | grep 'over_limit'
+cluster.demo/fortio|8080|local.ratelimit.over_limit: 5
+```
+
+Further, confirm the HTTP requests with the header `my-header: baz` from the `fortio-client` to the `fortio` service are not rate limited. This is because our rate limit policy is only applicable to HTTP requests with the header `my-header` and value `foo` based on the following descriptor rule applied earlier:
+```
+- key: my_header
+  value: foo
+  rate_limit:
+    unit: minute
+    requests_per_unit: 5
+```
+
+```console
+$ kubectl exec "$fortio_client" -n demo -c fortio-client -- fortio load -c 3 -n 10 -H "my-header: baz" http://fortio.demo.svc.cluster.local:8080
+Fortio 1.34.1 running at 8 queries per second, 8->8 procs, for 10 calls: http://fortio.demo.svc.cluster.local:8080
+22:57:16 I httprunner.go:98> Starting http test for http://fortio.demo.svc.cluster.local:8080 with 3 threads at 8.0 qps and parallel warmup
+Starting at 8 qps with 3 thread(s) [gomax 8] : exactly 10, 3 calls each (total 9 + 1)
+22:57:17 I periodic.go:721> T001 ended after 1.1304947s : 3 calls. qps=2.65370549724824
+22:57:17 I periodic.go:721> T002 ended after 1.1307771s : 3 calls. qps=2.6530427614779253
+22:57:17 I periodic.go:721> T000 ended after 1.5037149s : 4 calls. qps=2.6600787157193166
+Ended after 1.5037834s : 10 calls. qps=6.6499
+Sleep times : count 7 avg 0.52288017 +/- 0.03204 min 0.4827303 max 0.5549368 sum 3.6601612
+Aggregated Function Time : count 10 avg 0.00994919 +/- 0.00635 min 0.0034616 max 0.0251343 sum 0.0994919
+# range, mid point, percentile, count
+>= 0.0034616 <= 0.004 , 0.0037308 , 10.00, 1
+> 0.004 <= 0.005 , 0.0045 , 20.00, 1
+> 0.005 <= 0.006 , 0.0055 , 30.00, 1
+> 0.006 <= 0.007 , 0.0065 , 50.00, 2
+> 0.008 <= 0.009 , 0.0085 , 70.00, 2
+> 0.014 <= 0.016 , 0.015 , 80.00, 1
+> 0.016 <= 0.018 , 0.017 , 90.00, 1
+> 0.025 <= 0.0251343 , 0.0250671 , 100.00, 1
+# target 50% 0.007
+# target 75% 0.015
+# target 90% 0.018
+# target 99% 0.0251209
+# target 99.9% 0.025133
+Error cases : no data
+22:57:17 I httprunner.go:197> [0]   1 socket used, resolved to 10.96.151.249:8080
+22:57:17 I httprunner.go:197> [1]   1 socket used, resolved to 10.96.151.249:8080
+22:57:17 I httprunner.go:197> [2]   1 socket used, resolved to 10.96.151.249:8080
+Sockets used: 3 (for perfect keepalive, would be 3)
+Uniform: false, Jitter: false
+IP addresses distribution:
+10.96.151.249:8080: 3
+Code 200 : 10 (100.0 %)
+Response Header Sizes : count 10 avg 124.3 +/- 0.4583 min 124 max 125 sum 1243
+Response Body/Total Sizes : count 10 avg 124.3 +/- 0.4583 min 124 max 125 sum 1243
+All done 10 calls (plus 0 warmup) 9.949 ms avg, 6.6 qps
+```
+
+As seen above, all the `10` requests succeeded.
+```
+Code 200 : 10 (100.0 %)
+```
+
+#### headerValueMatch descriptor
+
+A `headerValueMatch` descriptor entry defines a descriptor entry that is generated when the request header matches the given set of HTTP header match criteria. OSM supports multiple header match operators in the form of `Exact, Prefix, Suffix, Regex, Contains, Present` match semantics.
+
+Let's update the `ratelimit-config` ConfigMap to rate limit requests that generate the descriptor key `header_match: foo` to 7 per minute.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ratelimit-config
+  namespace: rls
+data:
+  ratelimit-config.yaml: |
+    domain: test
+    descriptors:
+      # requests with the descriptor 'header_match: foo' are rate limited
+      # to 7 per minute
+      - key: header_match
+        value: foo
+        rate_limit:
+          unit: minute
+          requests_per_unit: 7
+EOF
+```
+> Note: it can take a few seconds for the RLS to load the configuration.
+
+Update the global rate limit policy targeting the `fortio` service to generate the descriptor `header_match: foo` to rate limit requests containing the header `my-header` and not containing the header `other-header` using the global rate limiter.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: policy.openservicemesh.io/v1alpha1
+kind: UpstreamTrafficSetting
+metadata:
+  name: fortio-tcp
+  namespace: demo
+spec:
+  host: fortio.demo.svc.cluster.local
+  rateLimit:
+    global:
+      http:
+        rateLimitService:
+          host: ratelimiter.rls.svc.cluster.local
+          port: 8081
+        domain: test
+        failOpen: false
+        timeout: 10s
+        descriptors:
+          - entries:
+            - headerValueMatch:
+                # key: header_match # default
+                value: foo
+                headers:
+                  - name: my-header
+                    present: true
+                  - name: other-header
+                    present: false
+EOF
+```
+
+Confirm the HTTP requests from the `fortio-client` to the `fortio` service containing the `my-header` header and not containing the `other-header` header are rate limited.
+
+Reset the stat counters on the `fortio` server pod's Envoy sidecar to see the impact of rate limiting.
+```bash
+osm proxy set reset_counters "$fortio_server" -n demo
+```
+
+```console
+$ kubectl exec "$fortio_client" -n demo -c fortio-client -- fortio load -c 3 -n 10 -H "my-header: baz" http://fortio.demo.svc.cluster.local:8080
+Fortio 1.34.1 running at 8 queries per second, 8->8 procs, for 10 calls: http://fortio.demo.svc.cluster.local:8080
+18:37:34 I httprunner.go:98> Starting http test for http://fortio.demo.svc.cluster.local:8080 with 3 threads at 8.0 qps and parallel warmup
+Starting at 8 qps with 3 thread(s) [gomax 8] : exactly 10, 3 calls each (total 9 + 1)
+18:37:35 W http_client.go:889> [2] Non ok http code 429 (HTTP/1.1 429)
+18:37:35 I periodic.go:721> T002 ended after 1.1387878s : 3 calls. qps=2.6343801716175745
+18:37:35 W http_client.go:889> [1] Non ok http code 429 (HTTP/1.1 429)
+18:37:35 I periodic.go:721> T001 ended after 1.1430429s : 3 calls. qps=2.624573408399632
+18:37:35 W http_client.go:889> [0] Non ok http code 429 (HTTP/1.1 429)
+18:37:35 I periodic.go:721> T000 ended after 1.5074722s : 4 calls. qps=2.6534486009095226
+Ended after 1.507513s : 10 calls. qps=6.6334
+Sleep times : count 7 avg 0.50088606 +/- 0.03464 min 0.4371301 max 0.5481652 sum 3.5062024
+Aggregated Function Time : count 10 avg 0.02777703 +/- 0.02278 min 0.0063771 max 0.0628465 sum 0.2777703
+# range, mid point, percentile, count
+>= 0.0063771 <= 0.007 , 0.00668855 , 20.00, 2
+> 0.012 <= 0.014 , 0.013 , 40.00, 2
+> 0.014 <= 0.016 , 0.015 , 50.00, 1
+> 0.016 <= 0.018 , 0.017 , 60.00, 1
+> 0.018 <= 0.02 , 0.019 , 70.00, 1
+> 0.06 <= 0.0628465 , 0.0614232 , 100.00, 3
+# target 50% 0.016
+# target 75% 0.0604744
+# target 90% 0.0618977
+# target 99% 0.0627516
+# target 99.9% 0.062837
+Error cases : count 3 avg 0.012477667 +/- 0.004384 min 0.0067722 max 0.0174308 sum 0.037433
+# range, mid point, percentile, count
+>= 0.0067722 <= 0.007 , 0.0068861 , 33.33, 1
+> 0.012 <= 0.014 , 0.013 , 66.67, 1
+> 0.016 <= 0.0174308 , 0.0167154 , 100.00, 1
+# target 50% 0.013
+# target 75% 0.0163577
+# target 90% 0.0170016
+# target 99% 0.0173879
+# target 99.9% 0.0174265
+18:37:35 I httprunner.go:197> [0]   1 socket used, resolved to 10.96.151.249:8080
+18:37:35 I httprunner.go:197> [1]   1 socket used, resolved to 10.96.151.249:8080
+18:37:35 I httprunner.go:197> [2]   1 socket used, resolved to 10.96.151.249:8080
+Sockets used: 3 (for perfect keepalive, would be 3)
+Uniform: false, Jitter: false
+IP addresses distribution:
+10.96.151.249:8080: 3
+Code 200 : 7 (70.0 %)
+Code 429 : 3 (30.0 %)
+Response Header Sizes : count 10 avg 87.3 +/- 57.15 min 0 max 125 sum 873
+Response Body/Total Sizes : count 10 avg 137.2 +/- 19.08 min 124 max 167 sum 1372
+All done 10 calls (plus 0 warmup) 27.777 ms avg, 6.6 qps
+```
+
+As seen above, only `7` out of `10` HTTP requests succeeded, while the remaining `3` requests were rate limited with a `429 (Too Many Requests)` response as per the rate limiting policy.
+```
+Code 200 : 7 (70.0 %)
+Code 429 : 3 (30.0 %)
+```
+
+Examine the stats to further confirm this.
+
+```console
+$ osm proxy get stats "$fortio_server" -n demo | grep 'over_limit'
+cluster.demo/fortio|8080|local.ratelimit.over_limit: 3
+```
+
+Confirm the HTTP requests from the `fortio-client` to the `fortio` service containing the `other-header` header are rate not limited as per the `present: false` policy configured for this header.
+
+```console
+$ kubectl exec "$fortio_client" -n demo -c fortio-client -- fortio load -c 3 -n 10 -H "other-header: baz" http://fortio.demo.svc.cluster.local:8080
+Fortio 1.34.1 running at 8 queries per second, 8->8 procs, for 10 calls: http://fortio.demo.svc.cluster.local:8080
+18:40:59 I httprunner.go:98> Starting http test for http://fortio.demo.svc.cluster.local:8080 with 3 threads at 8.0 qps and parallel warmup
+Starting at 8 qps with 3 thread(s) [gomax 8] : exactly 10, 3 calls each (total 9 + 1)
+18:41:00 I periodic.go:721> T002 ended after 1.1302201s : 3 calls. qps=2.6543502455849084
+18:41:00 I periodic.go:721> T001 ended after 1.1302202s : 3 calls. qps=2.6543500107324216
+18:41:00 I periodic.go:721> T000 ended after 1.5044186s : 4 calls. qps=2.65883444940125
+Ended after 1.50449s : 10 calls. qps=6.6468
+Sleep times : count 7 avg 0.52947463 +/- 0.03007 min 0.492957 max 0.5582885 sum 3.7063224
+Aggregated Function Time : count 10 avg 0.00537314 +/- 0.002502 min 0.0026129 max 0.0105128 sum 0.0537314
+# range, mid point, percentile, count
+>= 0.0026129 <= 0.003 , 0.00280645 , 10.00, 1
+> 0.003 <= 0.004 , 0.0035 , 40.00, 3
+> 0.004 <= 0.005 , 0.0045 , 60.00, 2
+> 0.005 <= 0.006 , 0.0055 , 70.00, 1
+> 0.006 <= 0.007 , 0.0065 , 80.00, 1
+> 0.009 <= 0.01 , 0.0095 , 90.00, 1
+> 0.01 <= 0.0105128 , 0.0102564 , 100.00, 1
+# target 50% 0.0045
+# target 75% 0.0065
+# target 90% 0.01
+# target 99% 0.0104615
+# target 99.9% 0.0105077
+Error cases : no data
+18:41:00 I httprunner.go:197> [0]   1 socket used, resolved to 10.96.151.249:8080
+18:41:00 I httprunner.go:197> [1]   1 socket used, resolved to 10.96.151.249:8080
+18:41:00 I httprunner.go:197> [2]   1 socket used, resolved to 10.96.151.249:8080
+Sockets used: 3 (for perfect keepalive, would be 3)
+Uniform: false, Jitter: false
+IP addresses distribution:
+10.96.151.249:8080: 3
+Code 200 : 10 (100.0 %)
+Response Header Sizes : count 10 avg 124 +/- 0 min 124 max 124 sum 1240
+Response Body/Total Sizes : count 10 avg 124 +/- 0 min 124 max 124 sum 1240
+All done 10 calls (plus 0 warmup) 5.373 ms avg, 6.6 qps
+```

--- a/content/en/docs/demos/local_rate_limit_connections.md
+++ b/content/en/docs/demos/local_rate_limit_connections.md
@@ -196,6 +196,12 @@ The following demo shows a client [fortio-client](https://github.com/fortio/fort
     ```
 
 1. Confirm the burst capability allows a burst of connections within a small window of time.
+
+    Reset the stat counters on the `fortio` server pod's Envoy sidecar to see the impact of rate limiting.
+    ```bash
+    osm proxy set reset_counters "$fortio_server" -n demo
+    ```
+
     ```console
     $ kubectl exec "$fortio_client" -n demo -c fortio-client -- fortio load -qps -1 -c 3 -n 10 tcp://fortio.demo.svc.cluster.local:8078
     Fortio 1.32.3 running at -1 queries per second, 8->8 procs, for 10 calls: tcp://fortio.demo.svc.cluster.local:8078
@@ -229,8 +235,8 @@ The following demo shows a client [fortio-client](https://github.com/fortio/fort
     All done 10 calls (plus 0 warmup) 1.531 ms avg, 1897.1 qps
     ```
 
-    Further, examine the stats to confirm the burst allows additional connections to go through. The number of connections rate limited hasn't increased since our previous rate limit test before we configured the burst setting.
+    Further, examine the stats to confirm the burst allows additional connections to go through.
     ```console
     $ osm proxy get stats "$fortio_server" -n demo | grep 'fortio.*8078.*rate_limit'
-    local_rate_limit.inbound_demo/fortio_8078_tcp.rate_limited: 7
+    local_rate_limit.inbound_demo/fortio_8078_tcp.rate_limited: 0
     ```

--- a/content/en/docs/demos/local_rate_limit_http.md
+++ b/content/en/docs/demos/local_rate_limit_http.md
@@ -179,7 +179,7 @@ The following demo shows a client sending HTTP requests to the `fortio` service.
     All done 10 calls (plus 0 warmup) 3.183 ms avg, 6.7 qps
     ```
 
-    As seen above, only `3` out of `10` HTTP requests succeeded, while the remaining `7` requests were rate limited as per the rate limiting policy.
+    As seen above, only `3` out of `10` HTTP requests succeeded, while the remaining `7` requests were rate limited with a `429 (Too Many Requests)` response as per the rate limiting policy.
     ```
     Code 200 : 3 (30.0 %)
     Code 429 : 7 (70.0 %)

--- a/content/en/docs/guides/traffic_management/rate_limiting.md
+++ b/content/en/docs/guides/traffic_management/rate_limiting.md
@@ -1,6 +1,6 @@
 ---
 title: "Rate Limiting"
-description: "Using rircuit breaking to control the throughput of traffic"
+description: "Using rate limiting to control the throughput of traffic"
 type: docs
 weight: 12
 ---
@@ -11,17 +11,21 @@ Rate limiting is an effective mechanism to control the throughput of traffic des
 
 Most commonly, when a large number of clients are sending traffic to a target host, if the target host becomes backed up, the downstream clients will overwhelm the upstream target host. In this scenario it is extremely difficult to configure a tight enough circuit breaking limit on each downstream host such that the system will operate normally during typical request patterns but still prevent cascading failure when the system starts to fail. In such scenarios, rate limiting traffic to the target host is effective.
 
-OSM supports server-side rate limiting per target host, also referred to as `local per-instance rate limiting`.
+OSM supports two forms of rate limiting:
+1. `Local per-instance rate limiting` at each upstream host
+2. `Global rate limiting` using a global gRPC rate limiting service
 
-## Configuring local per-instance rate limiting
-
-OSM leverages its [UpstreamTrafficSetting API][1] to configure rate limiting attributes for traffic directed to an upstream service. We use the term `upstream service` to refer to a service that receives connections and requests from clients and return responses. The specification enables configuring local rate limiting attributes for an upstream service at the connection and request level. OSM leverages [Envoy's local rate limiting functionality](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/local_rate_limit_filter#config-network-filters-local-rate-limit) to implement per-instance local rate limiting at each upstream host.
+OSM leverages its [UpstreamTrafficSetting API](/docs/api_reference/policy/v1alpha1/#policy.openservicemesh.io/v1alpha1.UpstreamTrafficSettingSpec) to configure rate limiting attributes for traffic directed to an upstream service. We use the term `upstream service` to refer to a service that receives connections/requests from clients and returns responses.
 
 Each `UpstreamTrafficSetting` configuration targets an upstream host defined by the `spec.host` field. For a Kubernetes service `my-svc` in the namespace `my-namespace`, the `UpstreamTrafficSetting` resource must be created in the namespace `my-namespace`, and `spec.host` must be an FQDN of the form `my-svc.my-namespace.svc.cluster.local`.
 
+## Configuring local per-instance rate limiting
+
+ The specification enables configuring local rate limiting attributes for an upstream service at the connection and request level. OSM leverages [Envoy's local rate limiting capability](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/local_rate_limit_filter#config-network-filters-local-rate-limit) to implement per-instance local rate limiting at each upstream host.
+
 Local rate limiting is applicable at both the TCP (L4) connection and HTTP request level, and can be configured using the `rateLimit.local` attribute in the `UpstreamTrafficSetting` resource. TCP settings apply to both TCP and HTTP traffic, while HTTP settings only apply to HTTP traffic. Both TCP and HTTP level rate limiting is enforced using a token bucket rate limiter.
 
-### Rate limiting TCP connections
+### Local rate limiting of TCP connections
 
 TCP connections can be rate limited per unit of time. An optional burst limit can be specified to allow a burst of connections above the baseline rate to accommodate for connection bursts in a short interval of time. TCP rate limiting is applied as a token bucket rate limiter at the network filter chain of the upstream service’s inbound listener. Each incoming connection processed by the filter consumes a single token. If the token is available, the connection will be allowed. If no tokens are available, the connection will be immediately closed.
 
@@ -35,7 +39,7 @@ The following attributes nested under `spec.rateLimit.local.tcp` define the rate
 
 Refer to the [TCP local rate limiting API](/docs/api_reference/policy/v1alpha1/#policy.openservicemesh.io/v1alpha1.TCPLocalRateLimitSpec) for additional information regarding API usage.
 
-### Rate limiting HTTP requests
+### Local rate limiting of HTTP requests
 
 HTTP requests can be rate limited per unit of time. An optional burst limit can be specified to allow a burst of requests above the baseline rate to accommodate for request bursts in a short interval of time. HTTP rate limiting is applied as a token bucket rate limiter at the virtual host and/or HTTP route level at the upstream backend, depending on the rate limiting configuration. Each incoming request processed by the filter consumes a single token. If the token is available, the request will be allowed. If no tokens are available, the request will receive the configured rate limit status.
 
@@ -53,10 +57,133 @@ The following rate limiting attributes can be configured for HTTP traffic:
 
 - `responseHeadersToAdd`: The list of HTTP headers as key-value pairs that should be added to each response for requests that have been rate limited.
 
+
+## Configuring global rate limiting
+
+ The specification enables configuring global rate limiting attributes for an upstream service at the connection and request level. OSM leverages [Envoy's global rate limiting capability](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_features/global_rate_limiting#arch-overview-global-rate-limit) to implement rate limiting by making calls to a global gRPC Rate Limit Service (RLS). Any service that implements the [defined RPC/IDL protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ratelimit/v3/rls.proto#envoy-v3-api-file-envoy-service-ratelimit-v3-rls-proto) can be used as the global rate limit service.
+
+Global rate limiting is applicable at both the TCP (L4) connection and HTTP (L7) request level, and can be configured using the `rateLimit.global` attribute in the `UpstreamTrafficSetting` resource. TCP settings apply to both TCP and HTTP traffic, while HTTP settings only apply to HTTP traffic. Both TCP and HTTP level rate limiting is enforced by calling the rate limit service for every new connection/request to make a rate limit decision.
+
+Unlike local rate limit configuration, global rate limit configuration does not directly define a rate limit policy for the target upstream host. Instead, global rate limiting is enforced by specifying a descriptor set in the `UpstreamTrafficSetting` configuration. A descriptor set is a list of hierarchical entries that are used by the Rate Limit Service (RLS) to determine the final rate limit key and overall allowed limit. The specified set of descriptors will be generated and sent to the RLS for each connection/request to make a rate limit decision.
+
+### Global rate limiting of TCP connections
+
+TCP connections from downstream clients inbound on an upstream host can be rate limited using a global rate limiter service. The configuration specifies a specific domain and descriptor set to rate limit on. This has the ultimate effect of rate limiting connections per second that transit the upstream host's inbound listener.
+
+Envoy supports configuring static key-value pairs as descriptor entries to use in the rate limit service request for TCP connections.
+
+For example, to rate limit TCP connections on the `foo.demo.svc.cluster.local` service in the `demo` namespace using an external RLS `ratelimiter.rls.svc.cluster.local` serving requests on port `8081`, for the descriptor entry `my_key: my_value` and rate limit domain `test` will look as follows:
+
+```yaml
+apiVersion: policy.openservicemesh.io/v1alpha1
+kind: UpstreamTrafficSetting
+metadata:
+  name: foo
+  namespace: demo
+spec:
+  host: foo.demo.svc.cluster.local
+  rateLimit:
+    global:
+      tcp:
+        rateLimitService:
+          host: ratelimiter.rls.svc.cluster.local
+          port: 8081
+        domain: test
+        failOpen: false
+        timeout: 10s
+        descriptors:
+          - entries:
+            - key: my_key
+              value: my_value
+```
+
+Refer to the [Global TCP rate limit API](/docs/api_reference/policy/v1alpha1/#policy.openservicemesh.io/v1alpha1.TCPGlobalRateLimitSpec) to learn more about the configuration attributes and an [end-to-end demo](/docs/demos/global_rate_limit_connections) to understand the global TCP rate limiting capability.
+
+### Global rate limiting of HTTP requests
+
+HTTP connections from downstream clients inbound on an upstream host can be rate limited using a global rate limit service. The configuration specifies a specific domain and descriptor set to rate limit on. This has the ultimate effect of rate limiting requests per second that transit the upstream host's inbound listener.
+
+The rate limit configuration can be applied at both the virtual host and route level. The policy defines a set of request descriptors that will be generated and sent to the external RLS to make a rate limit decision on each request. A list of descriptors, each comprising of one or more descriptor entries, is specified and generated based on different criteria. If an entry specified within a descriptor cannot be generated for a request, the entire descriptor is not generated. When multiple descriptors are specified, all descriptors that can be generated will be generated and sent to the rate limit service. Refer to the [Envoy documentation on composing descriptors](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/rate_limit_filter#composing-actions) for more information.
+
+OSM supports different kinds of descriptor entries for HTTP requests, namely `genericKey`, `remoteAddress`, `requestHeader`, and `headerValueMatch`. The following sections describe each of them.
+
+#### genericKey descriptor
+
+The [genericKey descriptor entry](/docs/api_reference/policy/v1alpha1/#policy.openservicemesh.io/v1alpha1.GenericKeyDescriptorEntry) defines a static key-value pair. By default, the `genericKey` descriptor entry uses `generic_key` as it's descriptor key if unspecified.
+
+For example, the following configuration generates the descriptor `("my_key", "my_value")`:
+```yaml
+rateLimit:
+  global:
+    http:
+      descriptors:
+        - entries:
+          - genericKey:
+              key: my_key
+              value: my_value
+```
+
+Refer to the [genericKey descriptor demo](/docs/demos/global_rate_limit_http/#generickey-descriptor) to learn more about using the `genericKey` descriptor entry.
+
+#### remoteAddress descriptor
+
+The [remoteAddress descriptor entry](/docs/api_reference/policy/v1alpha1/#policy.openservicemesh.io/v1alpha1.RemoteAddressDescriptorEntry) has a key of `remote_address` and a value of the client IP address that is populated using the trusted address from the `x-forwarded-for` HTTP header.
+
+For example, the following configuration generates the descriptor `("remote_address", "<trusted address from x-forwarded-for>")`:
+```yaml
+rateLimit:
+  global:
+    http:
+      descriptors:
+        - entries:
+          - remoteAddress: {}
+```
+
+Refer to the [remoteAddress descriptor demo](/docs/demos/global_rate_limit_http/#remoteaddress-descriptor) to learn more about using the `remoteAddress` descriptor entry.
+
+#### requestHeader descriptor
+
+The [requestHeader descriptor entry](/docs/api_reference/policy/v1alpha1/#policy.openservicemesh.io/v1alpha1.RequestHeaderDescriptorEntry) defines a static key-value pair for the descriptor entry that is generated only when the request header matches the given header name. The value of the descriptor entry is derived from the value of the header present in the request. If the header is not present, the descriptor is not generated.
+
+For example, the following configuration generates the descriptor `("my_header", "<value from some-header>")`:
+```yaml
+rateLimit:
+  global:
+    http:
+      descriptors:
+        - entries:
+          - requestHeader:
+              name: some-header
+              key: my_header
+```
+
+Refer to the [requestHeader descriptor demo](/docs/demos/global_rate_limit_http/#requestheader-descriptor) to learn more about using the `requestHeader` descriptor entry.
+
+#### headerValueMatch descriptor
+
+The [headerValueMatch descriptor entry](/docs/api_reference/policy/v1alpha1/#policy.openservicemesh.io/v1alpha1.HeaderValueMatchDescriptorEntry) defines a descriptor entry that is generated when the request header matches the given set of [HTTP header match criteria](/docs/api_reference/policy/v1alpha1/#policy.openservicemesh.io/v1alpha1.HTTPHeaderMatcher). OSM supports multiple header match operators in the form of `Exact, Prefix, Suffix, Regex, Contains, Present` match semantics.
+
+For example, the following configuration generates the descriptor `("header_match", "foo")` for requests that have the header `my-header` present and that don't have the header `other-header` present.
+```yaml
+rateLimit:
+  global:
+    http:
+      descriptors:
+        - entries:
+          - headerValueMatch:
+              key: header_match
+              value: foo
+              headers:
+                - name: my-header
+                  present: true
+                - name: other-header
+                  present: false
+```
+
 ## Demos
 
 To learn more about configuring rate limting, refer to the following demo guides:
 - [Local rate limiting of TCP connections](/docs/demos/local_rate_limit_connections)
 - [Local rate limiting of HTTP requests](/docs/demos/local_rate_limit_http)
-
-[1]: /docs/api_reference/policy/v1alpha1/#policy.openservicemesh.io/v1alpha1.UpstreamTrafficSettingSpec
+- [Global rate limiting of TCP connections](/docs/demos/global_rate_limit_connections)
+- [Global rate limiting of HTTP requests](/docs/demos/global_rate_limit_http/)


### PR DESCRIPTION
- adds a demo guide for global rate limit of HTTP traffic

- updates existing rate limit docs for consistency

- updates API reference guide

Part of openservicemesh/osm#2018
