### PR TITLE
docs: remove zh localization from search indexing

### DIFF
--- a/themes/dosmy/layouts/robots.txt
+++ b/themes/dosmy/layouts/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
-Disallow:
+Disallow: /zh/
 Sitemap: {{ .Site.BaseURL }}/sitemap.xml


### PR DESCRIPTION
Signed-off-by: Zach Rhoads <zarhoads@microsoft.com>

Backporting this PR to 1.2 release: https://github.com/openservicemesh/osm-docs/pull/442