### PR TITLE
fix lang code lost in rendered link

### DIFF
--- a/themes/dosmy/layouts/_default/_markup/render-link.html
+++ b/themes/dosmy/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | relLangURL | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
After applying the localization feature, the link rendered in a non-default language page lost language code. For example, if we click the internal link on page https://release-v1-2.docs.openservicemesh.io/zh/, it will direct us to the English page.

To fix this, a markdown rendering link hook is involved in which using Hugo function [absLangURL](https://gohugo.io/functions/abslangurl/) will convert the link to the one with the correct language code.

BTW, the commit should be synced to the main branch too.