### PR TITLE
docs: add envoy access log guide

### DIFF
--- a/content/en/docs/api_reference/config/v1alpha2.md
+++ b/content/en/docs/api_reference/config/v1alpha2.md
@@ -121,6 +121,168 @@ IngressGatewayCertSpec
 </tr>
 </tbody>
 </table>
+<h3 id="config.openservicemesh.io/v1alpha2.ExtensionService">ExtensionService
+</h3>
+<p>
+<p>ExtensionService defines the configuration of the external service
+that an OSM managed mesh integrates with.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-20.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Object&rsquo;s metadata.</p>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha2.ExtensionServiceSpec">
+ExtensionServiceSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec defines the specification of the extension service.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>host</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Host defines the hostname of the extension service.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>port</code><br/>
+<em>
+uint32
+</em>
+</td>
+<td>
+<p>Port defines the port number of the extension service.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>protocol</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Protocol defines the protocol of the extension service.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>connectTimeout</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ConnectTimeout defines the timeout for connecting to the extension service.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="config.openservicemesh.io/v1alpha2.ExtensionServiceSpec">ExtensionServiceSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#config.openservicemesh.io/v1alpha2.ExtensionService">ExtensionService</a>)
+</p>
+<p>
+<p>ExtensionServiceSpec defines the specification of the extension service.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>host</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Host defines the hostname of the extension service.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>port</code><br/>
+<em>
+uint32
+</em>
+</td>
+<td>
+<p>Port defines the port number of the extension service.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>protocol</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Protocol defines the protocol of the extension service.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>connectTimeout</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ConnectTimeout defines the timeout for connecting to the extension service.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="config.openservicemesh.io/v1alpha2.ExternalAuthzSpec">ExternalAuthzSpec
 </h3>
 <p>
@@ -649,6 +811,31 @@ string
 <p>TrustDomain is the trust domain to use as a suffix in Common Names for new certificates.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>intent</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateIntent">
+MeshRootCertificateIntent
+</a>
+</em>
+</td>
+<td>
+<p>Intent of the MeshRootCertificate resource</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spiffeEnabled</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>SpiffeEnabled will add a SPIFFE ID to the certificates, creating a SPIFFE compatible x509 SVID document
+To use SPIFFE ID for validation and routing, &lsquo;enableSPIFFE&rsquo; must be true in the MeshConfig after the MeshRootCertificate is made &lsquo;active&rsquo;</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -668,6 +855,241 @@ MeshRootCertificateStatus
 </tr>
 </tbody>
 </table>
+<h3 id="config.openservicemesh.io/v1alpha2.MeshRootCertificateComponentStatus">MeshRootCertificateComponentStatus
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em><a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateComponentStatuses">MeshRootCertificateComponentStatuses</a>)
+</p>
+<p>
+<p>MeshRootCertificateComponentStatus specifies the status of the certificate component,
+can be (<code>Issuing</code>, <code>Validating</code>, <code>Unknown</code>).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;issuing&#34;</p></td>
+<td><p>Issuing means that the root cert described by this MRC is now issuing certs for this component of OSM.</p>
+</td>
+</tr><tr><td><p>&#34;unknown&#34;</p></td>
+<td><p>UnknownComponentStatus means that the use of the root cert described by this MRC is in an unknown state for this
+component.</p>
+</td>
+</tr><tr><td><p>&#34;unused&#34;</p></td>
+<td><p>Unused means that the root cert described by this MRC is unused.</p>
+</td>
+</tr><tr><td><p>&#34;validating&#34;</p></td>
+<td><p>Validating means that the root cert&rsquo;s cert chain, described by this MRC is now part of the CABundle used to
+validate requests for this component..</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="config.openservicemesh.io/v1alpha2.MeshRootCertificateComponentStatuses">MeshRootCertificateComponentStatuses
+</h3>
+<p>
+(<em>Appears on:</em><a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateStatus">MeshRootCertificateStatus</a>)
+</p>
+<p>
+<p>MeshRootCertificateComponentStatuses is the set of statuses for each certificate component in the cluster.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>validatingWebhook</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateComponentStatus">
+MeshRootCertificateComponentStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>mutatingWebhook</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateComponentStatus">
+MeshRootCertificateComponentStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>xdsControlPlane</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateComponentStatus">
+MeshRootCertificateComponentStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>sidecar</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateComponentStatus">
+MeshRootCertificateComponentStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>bootstrap</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateComponentStatus">
+MeshRootCertificateComponentStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>gateway</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateComponentStatus">
+MeshRootCertificateComponentStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="config.openservicemesh.io/v1alpha2.MeshRootCertificateCondition">MeshRootCertificateCondition
+</h3>
+<p>
+(<em>Appears on:</em><a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateStatus">MeshRootCertificateStatus</a>)
+</p>
+<p>
+<p>MeshRootCertificateCondition defines the condition of the MeshRootCertificate resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateConditionType">
+MeshRootCertificateConditionType
+</a>
+</em>
+</td>
+<td>
+<p>Type of the condition,
+one of (<code>Ready</code>, <code>Accepted</code>, <code>IssuingRollout</code>, <code>ValidatingRollout</code>, <code>IssuingRollback</code>, <code>ValidatingRollback</code>).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateConditionStatus">
+MeshRootCertificateConditionStatus
+</a>
+</em>
+</td>
+<td>
+<p>Status of the condition, one of (<code>True</code>, <code>False</code>, <code>Unknown</code>).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastTransitionTime</code><br/>
+<em>
+<a href="https://v1-20.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LastTransitionTime is the timestamp corresponding to the last status
+change of this condition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reason is a brief machine readable explanation for the condition&rsquo;s last
+transition (should be in camelCase).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Message is a human readable description of the details of the last
+transition, complementing reason.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="config.openservicemesh.io/v1alpha2.MeshRootCertificateConditionStatus">MeshRootCertificateConditionStatus
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em><a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateCondition">MeshRootCertificateCondition</a>)
+</p>
+<p>
+<p>MeshRootCertificateConditionStatus specifies the status of the MeshRootCertificate condition,
+one of (<code>True</code>, <code>False</code>, <code>Unknown</code>).</p>
+</p>
+<h3 id="config.openservicemesh.io/v1alpha2.MeshRootCertificateConditionType">MeshRootCertificateConditionType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em><a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateCondition">MeshRootCertificateCondition</a>)
+</p>
+<p>
+<p>MeshRootCertificateConditionType specifies the type of the condition,
+one of (<code>Ready</code>, <code>Accepted</code>, <code>IssuingRollout</code>, <code>ValidatingRollout</code>, <code>IssuingRollback</code>, <code>ValidatingRollback</code>).</p>
+</p>
+<h3 id="config.openservicemesh.io/v1alpha2.MeshRootCertificateIntent">MeshRootCertificateIntent
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em><a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateSpec">MeshRootCertificateSpec</a>)
+</p>
+<p>
+<p>MeshRootCertificateIntent specifies the intent of the MeshRootCertificate
+can be (Active, Passive).</p>
+</p>
 <h3 id="config.openservicemesh.io/v1alpha2.MeshRootCertificateSpec">MeshRootCertificateSpec
 </h3>
 <p>
@@ -708,6 +1130,31 @@ string
 <p>TrustDomain is the trust domain to use as a suffix in Common Names for new certificates.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>intent</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateIntent">
+MeshRootCertificateIntent
+</a>
+</em>
+</td>
+<td>
+<p>Intent of the MeshRootCertificate resource</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spiffeEnabled</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>SpiffeEnabled will add a SPIFFE ID to the certificates, creating a SPIFFE compatible x509 SVID document
+To use SPIFFE ID for validation and routing, &lsquo;enableSPIFFE&rsquo; must be true in the MeshConfig after the MeshRootCertificate is made &lsquo;active&rsquo;</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="config.openservicemesh.io/v1alpha2.MeshRootCertificateStatus">MeshRootCertificateStatus
@@ -716,7 +1163,7 @@ string
 (<em>Appears on:</em><a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificate">MeshRootCertificate</a>)
 </p>
 <p>
-<p>MeshRootCertificateStatus defines the status of the MeshRootCertificate resource</p>
+<p>MeshRootCertificateStatus defines the status of the MeshRootCertificate resource.</p>
 </p>
 <table>
 <thead>
@@ -734,8 +1181,52 @@ string
 </em>
 </td>
 <td>
-<p>State specifies the state of the certificate provider
+<p>State specifies the state of the certificate provider.
 All states are specified in constants.go</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>transitionAfter</code><br/>
+<em>
+<a href="https://v1-20.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>If present, this MRC can transition to the next state in the state machine after this timestamp.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>componentStatuses</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateComponentStatuses">
+MeshRootCertificateComponentStatuses
+</a>
+</em>
+</td>
+<td>
+<p>Set of statuses for each certificate component in the cluster (e.g. webhooks, bootstrap, etc.)
+NOTE: There is a caveat that since these components belong to horizontally scalable pods, it is possible that not
+all of these components will be ready. That is, one controller might mark the ADS server as ready, while all other
+controllers have yet to rotate their controller cert.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>conditions</code><br/>
+<em>
+<a href="#config.openservicemesh.io/v1alpha2.MeshRootCertificateCondition">
+[]MeshRootCertificateCondition
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of status conditions to indicate the status of a MeshRootCertificate.
+Known condition types are <code>Ready</code> and <code>InvalidRequest</code>.</p>
 </td>
 </tr>
 </tbody>
@@ -1415,5 +1906,5 @@ SecretKeyReferenceSpec
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>f890cb73</code>.
+on git commit <code>a65cd374</code>.
 </em></p>

--- a/content/en/docs/api_reference/policy/v1alpha1.md
+++ b/content/en/docs/api_reference/policy/v1alpha1.md
@@ -391,6 +391,139 @@ The destination port of the traffic is matched against the list of Ports specifi
 </tr>
 </tbody>
 </table>
+<h3 id="policy.openservicemesh.io/v1alpha1.EnvoyAccessLogConfig">EnvoyAccessLogConfig
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.TelemetrySpec">TelemetrySpec</a>)
+</p>
+<p>
+<p>EnvoyAccessLogConfig defines the Envoy access log configuration.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>format</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Format defines the Envoy access log format.
+The format can either be unstructured or structured (e.g. JSON).
+Refer to <a href="https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#format-strings">https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#format-strings</a>
+regarding how a format string can be specified.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>openTelemetry</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.EnvoyAccessLogOpenTelemetryConfig">
+EnvoyAccessLogOpenTelemetryConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>OpenTelemetry defines the OpenTelemetry configuration used to export the
+Envoy access logs to an OpenTelemetry collector.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.EnvoyAccessLogOpenTelemetryConfig">EnvoyAccessLogOpenTelemetryConfig
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.EnvoyAccessLogConfig">EnvoyAccessLogConfig</a>)
+</p>
+<p>
+<p>EnvoyAccessLogOpenTelemetryConfig defines the Envoy access log OpenTelemetry
+configuration.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>extensionService</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.ExtensionServiceRef">
+ExtensionServiceRef
+</a>
+</em>
+</td>
+<td>
+<p>ExtensionService defines the referenence to ExtensionService resource
+corresponding to the OpenTelemetry collector the access log should be exported to.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>attributes</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Attributes defines key-value pairs as additional metadata corresponding access log record.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.ExtensionServiceRef">ExtensionServiceRef
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.EnvoyAccessLogOpenTelemetryConfig">EnvoyAccessLogOpenTelemetryConfig</a>)
+</p>
+<p>
+<p>ExtensionServiceRef defines the namespace and name of the ExtensionService resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>namespace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Namespace defines the namespaces of the ExtensionService resource.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name defines the name of the ExtensionService resource.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="policy.openservicemesh.io/v1alpha1.GenericKeyDescriptorEntry">GenericKeyDescriptorEntry
 </h3>
 <p>
@@ -763,6 +896,7 @@ don&rsquo;t conflict.</p>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Descriptors defines the list of rate limit descriptors to use
 in the rate limit service request.</p>
 </td>
@@ -2300,6 +2434,188 @@ certificate presented by the client.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="policy.openservicemesh.io/v1alpha1.Telemetry">Telemetry
+</h3>
+<p>
+<p>Telemetry defines the telemetry configuration for workloads in the mesh.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-20.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Object&rsquo;s metadata</p>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.TelemetrySpec">
+TelemetrySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the UpstreamTrafficSetting policy specification</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>selector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Selector defines the pod label selector for pods the Telemetry
+configuration is applicable to. It selects pods with matching label keys
+and values. If not specified, the configuration applies to all pods
+in the Telemetry resource&rsquo;s namespace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>accessLog</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.EnvoyAccessLogConfig">
+EnvoyAccessLogConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AccessLog defines the Envoy access log configuration.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.TelemetryStatus">
+TelemetryStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status is the status of the TelemetryStatus resource.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.TelemetrySpec">TelemetrySpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.Telemetry">Telemetry</a>)
+</p>
+<p>
+<p>TelemetrySpec defines the Telemetry specification applicable to workloads
+in the mesh.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>selector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Selector defines the pod label selector for pods the Telemetry
+configuration is applicable to. It selects pods with matching label keys
+and values. If not specified, the configuration applies to all pods
+in the Telemetry resource&rsquo;s namespace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>accessLog</code><br/>
+<em>
+<a href="#policy.openservicemesh.io/v1alpha1.EnvoyAccessLogConfig">
+EnvoyAccessLogConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AccessLog defines the Envoy access log configuration.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="policy.openservicemesh.io/v1alpha1.TelemetryStatus">TelemetryStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#policy.openservicemesh.io/v1alpha1.Telemetry">Telemetry</a>)
+</p>
+<p>
+<p>TelemetryStatus defines the status of a TelemetryStatus resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>currentStatus</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CurrentStatus defines the current status of a TelemetryStatus resource.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reason defines the reason for the current status of a TelemetryStatus resource.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="policy.openservicemesh.io/v1alpha1.UpstreamTrafficSetting">UpstreamTrafficSetting
 </h3>
 <p>
@@ -2555,5 +2871,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>dddb8fa5</code>.
+on git commit <code>a65cd374</code>.
 </em></p>

--- a/content/en/docs/guides/observability/envoy_access_logs.md
+++ b/content/en/docs/guides/observability/envoy_access_logs.md
@@ -1,0 +1,189 @@
+---
+title: "Envoy Access Logs"
+description: "Configuring Envoy access logs"
+type: docs
+weight: 3
+---
+
+# Envoy Access Logs
+
+Envoy proxies log access information to their standard output. The access logs can be observed by viewing the Envoy sidecar container's logs. OSM allows configuring the access log format per pod, namespace, or globally throughout the mesh. Additionally, OSM allows exporting the access logs from one or more pods in the mesh to an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) to receive and process telemetry data in a centralized manner.
+
+
+## Configuring Envoy access log format
+
+Envoy access logs contain information about various attributes of the traffic proxied through Envoy. OSM enables a default set of fields that are logged as a part of Envoy’s access logging capability in JSON format. For e.g, access logs for HTTP traffic may look as follows:
+
+```json
+{"bytes_sent":0,"request_id":"7feeda0a-31d6-4da1-b046-c5f0a1614255","protocol":"HTTP/1.1","method":"HEAD","time_to_first_byte":504,"start_time":"2022-09-08T16:41:31.933Z","response_code_details":"via_upstream","user_agent":"curl/7.85.0-DEV","upstream_host":"127.0.0.1:14001","bytes_received":0,"response_flags":"-","requested_server_name":"httpbin.httpbin.svc.cluster.local","x_forwarded_for":null,"response_code":200,"upstream_service_time":"409","path":"/","duration":508,"authority":"httpbin.httpbin:14001","upstream_cluster":"httpbin/httpbin|14001|local"}
+```
+
+OSM allows configuring the access log format per pod, namespace, or globally throughout the mesh. Additionally, the access log can be configured to be exported to a centralized OpenTelemetry Collector service. OSM leverages its [Telemetry API](/docs/api_reference/policy/v1alpha1/#policy.openservicemesh.io/v1alpha1.Telemetry) to configure access logging.
+
+The Telemetry API allows configuring access logging at 3 levels of granularity within the mesh, with the most specific configuration superseding less specific ones in case multiple configurations are applicable to an Envoy instance. The scope of the configuration is defined below in the order of specificity.
+
+1. Per pod(s): Similar to the behavior of the [Kubernetes Service selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#service-and-replicationcontroller), the `spec.selector` field can be set to select the pods in the resource’s namespace the configuration applies to.
+
+2. Per namespace: Configuration is applied in a namespace without the `spec.selector` field. All pods in the namespace inherit the configuration.
+
+3. Global: Configuration is applied without the `spec.selector` field in the OSM root namespace (osm-system by default).
+
+
+### Formats
+
+The access log format is specified using the `accessLog.format` field. It can either be a textual representation or a JSON string representation of the access log format string. Refer to the [Envoy access log documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#access-logging) to learn more about [access log format strings](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#format-strings) and the [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) that can be used to extract values inserted into the access logs.
+
+To generate an access log of the form `{"authority":"httpbin.httpbin:14001","bytes_sent":0,"bytes_received":0}` for the `httpbin` app in the `test` namespace, the configuration will look like:
+
+```yaml
+apiVersion: policy.openservicemesh.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: httpbin
+  namespace: test
+spec:
+  selector:
+    app: httpbin
+  accessLog:
+    format: '{"authority":"%REQ(:AUTHORITY)%","bytes_received":"%BYTES_RECEIVED%","bytes_sent":"%BYTES_SENT%"}'
+```
+
+To generate an access log of the form `[2022-10-19T20:23:53.392Z] authority=httpbin.httpbin:14001 bytes_received=0 bytes_sent=0` for all apps in the `test` namespace, the configuration will look like:
+
+```yaml
+apiVersion: policy.openservicemesh.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: test-log
+  namespace: test
+spec:
+  accessLog:
+    format: "[%START_TIME%] authority=%REQ(:AUTHORITY)% bytes_received=%BYTES_RECEIVED% bytes_sent=%BYTES_SENT%\n"
+```
+
+## Exporting access logs to an OpenTelemetry Collector
+
+The access logs can be configured to be exported to an OpenTelemetry Collector using the [Telemetry](/docs/api_reference/policy/v1alpha1/#policy.openservicemesh.io/v1alpha1.UpstreamTrafficSetting) and [ExtensionService](/docs/api_reference/config/v1alpha2/#config.openservicemesh.io/v1alpha2.ExtensionService) APIs. The Telemetry configuration specifies the pods for which access logs are to be exported and a reference to the OpenTelemetry Collector's ExtensionService configuration. The ExtensionService configuration specifies information regarding the OpenTelemetry Collector service.
+
+For example, to configure and export access logs for the `httpbin` app to an OpenTelemetry Collector service with the address `otel-collector.otel.svc.cluster.local` and port `4317`
+
+```yaml
+apiVersion: policy.openservicemesh.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: httpbin-log
+  namespace: httpbin
+spec:
+  selector:
+    app: httpbin
+
+  accessLog:
+    format: "[%START_TIME%] authority=%REQ(:AUTHORITY)% bytes_received=%BYTES_RECEIVED% bytes_sent=%BYTES_SENT%\n"
+
+    openTelemetry:
+      extensionService:
+        name: otel-collector
+        namespace: otel
+---
+apiVersion: config.openservicemesh.io/v1alpha2
+kind: ExtensionService
+metadata:
+  name: otel-collector
+  namespace: otel
+spec:
+  host: otel-collector.otel.svc.cluster.local
+  port: 4317
+  protocol: h2c
+```
+> Note: OSM currently only supports exporting the logs to the OpenTelemetry Collector over an unencrypted gRPC connection. The `protocol` field in the ExtensionService must be set to `h2c`.
+
+The above configuration will produce an access log similar to the below snipper on the Envoy sidecar of the `httpbin` pod:
+```
+[2022-10-20T15:53:13.764Z] authority=httpbin.httpbin:14001 bytes_received=0 bytes_sent=0
+```
+
+Additionally, since an OpenTelemetry configuration is specified, the access log will be exported to the OpenTelemetry Collector service. The access log message will be set in the [Body](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/logs/v1/logs.proto#L151) field of the OpenTelemetry log record as seen below in the OpenTelemetry Collector's logs:
+
+```
+2022-10-20T15:53:14.945Z	info	LogsExporter	{"kind": "exporter", "data_type": "logs", "name": "logging", "#logs": 1}
+2022-10-20T15:53:14.948Z	info	ResourceLog #0
+Resource SchemaURL:
+Resource labels:
+     -> log_name: STRING(otel-collector.otel.svc.cluster.local.4317)
+     -> zone_name: STRING()
+     -> cluster_name: STRING(httpbin.httpbin)
+     -> node_name: STRING(fabd4869-ce46-421e-a81b-977ebbc3c9b5)
+ScopeLogs #0
+ScopeLogs SchemaURL:
+InstrumentationScope
+LogRecord #0
+ObservedTimestamp: 1970-01-01 00:00:00 +0000 UTC
+Timestamp: 2022-10-20 15:53:13.764598 +0000 UTC
+Severity:
+Body: [2022-10-20T15:53:13.764Z] authority=httpbin.httpbin:14001 bytes_received=0 bytes_sent=0
+
+Trace ID:
+Span ID:
+Flags: 0
+	{"kind": "exporter", "data_type": "logs", "name": "logging"}
+```
+
+OSM allows configuring additional [attributes](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/logs/v1/logs.proto#L156) as metadata for the access logs exported to the OpenTelemetry Collector. This can be done by setting the `spec.accessLogs.openTelemetry.attributes` field.
+
+For example, the following configuration will produce the attribute `somekey: someValue` to be logged as attributes in the OpenTelemetry log record:
+```yaml
+apiVersion: policy.openservicemesh.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: httpbin-log
+  namespace: httpbin
+spec:
+  selector:
+    app: httpbin
+
+  accessLog:
+    format: "[%START_TIME%] authority=%REQ(:AUTHORITY)% bytes_received=%BYTES_RECEIVED% bytes_sent=%BYTES_SENT%\n"
+
+    openTelemetry:
+      extensionService:
+        name: otel-collector
+        namespace: otel
+      attributes:
+        someKey: "someValue"
+---
+apiVersion: config.openservicemesh.io/v1alpha2
+kind: ExtensionService
+metadata:
+  name: otel-collector
+  namespace: otel
+spec:
+  host: otel-collector.otel.svc.cluster.local
+  port: 4317
+  protocol: h2c
+```
+
+```
+2022-10-20T16:00:25.428Z	info	LogsExporter	{"kind": "exporter", "data_type": "logs", "name": "logging", "#logs": 1}
+2022-10-20T16:00:25.428Z	info	ResourceLog #0
+Resource SchemaURL:
+Resource labels:
+     -> log_name: STRING(otel-collector.otel.svc.cluster.local.4317)
+     -> zone_name: STRING()
+     -> cluster_name: STRING(httpbin.httpbin)
+     -> node_name: STRING(fabd4869-ce46-421e-a81b-977ebbc3c9b5)
+ScopeLogs #0
+ScopeLogs SchemaURL:
+InstrumentationScope
+LogRecord #0
+ObservedTimestamp: 1970-01-01 00:00:00 +0000 UTC
+Timestamp: 2022-10-20 16:00:24.382057 +0000 UTC
+Severity:
+Body: [2022-10-20T16:00:24.382Z] authority=httpbin.httpbin:14001 bytes_received=0 bytes_sent=0
+
+Attributes:
+     -> someKey: STRING(someValue)
+Trace ID:
+Span ID:
+Flags: 0
+	{"kind": "exporter", "data_type": "logs", "name": "logging"}
+```


### PR DESCRIPTION
Adds a guide describing Envoy access log
configuration. Also updates the API reference
docs.

Part of openservicemesh/osm#5136